### PR TITLE
FIXED: When RaftServer cannot find a leader, Return a more readable erro...

### DIFF
--- a/go/weed/weed_server/master_server_handlers_admin.go
+++ b/go/weed/weed_server/master_server_handlers_admin.go
@@ -133,7 +133,12 @@ func (ms *MasterServer) submitFromMasterServerHandler(w http.ResponseWriter, r *
 	if ms.Topo.IsLeader() {
 		submitForClientHandler(w, r, "localhost:"+strconv.Itoa(ms.port))
 	} else {
-		submitForClientHandler(w, r, ms.Topo.RaftServer.Leader())
+		masterUrl, err := ms.Topo.Leader()
+		if err != nil {
+			writeJsonError(w, r, http.StatusInternalServerError, err)
+		} else {
+			submitForClientHandler(w, r, masterUrl)
+		}
 	}
 }
 


### PR DESCRIPTION
...r.

Before:
curl -F "file=1234" "http://127.0.0.1:9333/submit"
{"error":"Post http:///dir/assign: http: no Host in request URL"}
After:
curl -F "file=1234" "http://127.0.0.1:9333/submit"
{"error":"Raft Server not initialized!"}