### PR TITLE
modify the dockerfile to make sure it was built successfully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM progrium/busybox
 WORKDIR /opt/weed
 
 RUN opkg-install curl
-RUN echo insecure >> ~/.curlrc
+RUN echo tlsv1 >> ~/.curlrc
 
 RUN \
   curl -Lks https://bintray.com$(curl -Lk http://bintray.com/chrislusf/seaweedfs/seaweedfs/_latestVersion | grep linux_amd64.tar.gz | sed -n "/href/ s/.*href=['\"]\([^'\"]*\)['\"].*/\1/gp") | gunzip | tar -xf - -C /opt/weed/ && \
-    mv weed_*/* /bin && \
+  mkdir ./bin &&  mv weed_*/* ./bin && \
   chmod +x ./bin/weed
 
 EXPOSE 8080


### PR DESCRIPTION
I modified the Dockerfile to make sure it was built successfully in the docker image build system.  You may find the build information and result via https://registry.hub.docker.com/u/carmark/seaweedfs/.

Currently, I used my forked repository to as the automated build source, it could be modified on the main upstream.

I did test the images on my local system, the result is following:
> Pulling the images
root@ubuntu:/opt/weed# docker pull carmark/seaweedfs
Pulling repository carmark/seaweedfs
81726418f76b: Download complete
511136ea3c5a: Download complete
46e263e5de56: Download complete
cf677a5f718c: Download complete
6adb1b0566e7: Download complete
fdb314abe596: Download complete
cfed5ebfc893: Download complete
653376e72714: Download complete
46bed15d45c7: Download complete
8cee90767cfe: Download complete
dec8c94e3698: Download complete
78cf586ab1ed: Download complete
4015db3642e3: Download complete
d1e4a4a9565a: Download complete
3477ebb06c99: Download complete
f7c81525d51d: Download complete
d06870be6507: Download complete
2a6be79a231b: Download complete
7941ec72b659: Download complete
Status: Downloaded newer image for carmark/seaweedfs:latest


>root@ubuntu:/opt/weed# docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
carmark/seaweedfs   latest              81726418f76b        4 minutes ago       23.27 MB
tomcat              latest              8623bfc2fe4a        4 weeks ago         345.5 MB
ubuntu              14.04               d0955f21bf24        6 weeks ago         188.3 MB
ubuntu              14.04.2             d0955f21bf24        6 weeks ago         188.3 MB
ubuntu              latest              d0955f21bf24        6 weeks ago         188.3 MB
ubuntu              trusty              d0955f21bf24        6 weeks ago         188.3 MB
ubuntu              trusty-20150320     d0955f21bf24        6 weeks ago         188.3 MB
hello-world         latest              e45a5af57b00        4 months ago        910 B


> Running the command on that container
root@ubuntu:/opt/weed# docker run -ti --entrypoint /bin/sh carmark/seaweedfs:latest
/opt/weed # ls
bin                        weed_0.70beta_linux_amd64
/opt/weed # pwd
/opt/weed
/opt/weed # uname -x
uname: invalid option -- 'x'
BusyBox v1.22.1 (2014-05-23 01:24:27 UTC) multi-call binary.
>
>Usage: uname [-amnrspv]
>
>Print system information
>
>	-a	Print all
>	-m	The machine (hardware) type
>	-n	Hostname
>	-r	OS release
>	-s	OS name (default)
>	-p	Processor type
>	-v	OS version
>
>/opt/weed #


Later, I will update the wiki page.