### PR TITLE
if mt != "application/octet-stream"

### DIFF
--- a/go/weed/weed_server/volume_server_handlers_read.go
+++ b/go/weed/weed_server/volume_server_handlers_read.go
@@ -89,7 +89,7 @@ func (vs *VolumeServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request)
 	}
 	if n.MimeSize > 0 {
 		mt := string(n.Mime)
-		if mt != "application/octet-stream" {
+		if !strings.HasPrefix(mt, "application/octet-stream") {
 			mtype = mt
 		}
 	}


### PR DESCRIPTION
became
if !strings.HasPrefix(mt, "application/octet-stream")

In our situation,
    mt can be 'application/octet-stream;charset=ISO-8859-1',
    so I think HasPrefix will be more accurate.