### PR TITLE
try to delete inconsistent file

### DIFF
--- a/go/topology/store_replicate.go
+++ b/go/topology/store_replicate.go
@@ -41,6 +41,8 @@ func ReplicatedWrite(masterNode string, s *storage.Store,
 				return err == nil
 			}) {
 				ret = 0
+				// If failed replication then try to delete inconsistent file
+				ReplicatedDelete(masterNode, s, volumeId, needle, r)
 				errorStatus = "Failed to write to replicas for volume " + volumeId.String()
 			}
 		}


### PR DESCRIPTION
I think we need to delete file in master volume (and replicas to) if there was a failed replication. In order thar vaccum can reclaim it in future. What do you think?