### PR TITLE
fix extract collection name from .dat file

### DIFF
--- a/go/storage/store.go
+++ b/go/storage/store.go
@@ -207,7 +207,7 @@ func (l *DiskLocation) loadExistingVolumes(needleMapKind NeedleMapType) {
 			if !dir.IsDir() && strings.HasSuffix(name, ".dat") {
 				collection := ""
 				base := name[:len(name)-len(".dat")]
-				i := strings.Index(base, "_")
+				i := strings.LastIndex(base, "_")
 				if i > 0 {
 					collection, base = base[0:i], base[i+1:]
 				}
@@ -216,6 +216,8 @@ func (l *DiskLocation) loadExistingVolumes(needleMapKind NeedleMapType) {
 						if v, e := NewVolume(l.Directory, collection, vid, needleMapKind, nil, nil); e == nil {
 							l.volumes[vid] = v
 							glog.V(0).Infof("data file %s, replicaPlacement=%s v=%d size=%d ttl=%s", l.Directory+"/"+name, v.ReplicaPlacement, v.Version(), v.Size(), v.Ttl.String())
+						} else {
+							glog.V(0).Infof("new volume %s error %s", name, e)
 						}
 					}
 				}


### PR DESCRIPTION
The name of a collection like 'something_something' is badly taken from a .dat file name.