### PR TITLE
Allow whitelisting by CIDR range, not just literally.

### DIFF
--- a/go/security/guard.go
+++ b/go/security/guard.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+        "regexp"
 	"net/http"
 
 	"github.com/chrislusf/seaweedfs/go/glog"
@@ -88,6 +89,26 @@ func (g *Guard) checkWhiteList(w http.ResponseWriter, r *http.Request) error {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err == nil {
 		for _, ip := range g.whiteList {
+
+                        // If the whitelist entry contains a "/" it
+                        // is a CIDR range, and we should check the
+                        // remote host is within it
+                        match, _ := regexp.MatchString("/", ip)
+                        if ( match ) {
+                               _, cidrnet, err := net.ParseCIDR(ip)
+                               if err != nil {
+                               		panic(err)
+                               }
+                               remote := net.ParseIP(host)
+                               if cidrnet.Contains(remote) {
+                               		return nil
+                               }
+                        }
+
+
+                        //
+                        // Otherwise we're looking for a literal match.
+                        //
 			if ip == host {
 				return nil
 			}


### PR DESCRIPTION
This allows you to write something like this:

         /usr/local/bin/weed master -mdir /srv/weed/master -whiteList=192.168.0.0/24,127.0.0.1

This will whitelist all the 192.168.0.XX hosts, as well as localhost.