### PR TITLE
[bug fix]weed daemon exit due to hangup signal when terminal close

### DIFF
--- a/go/weed/signal_handling.go
+++ b/go/weed/signal_handling.go
@@ -11,11 +11,13 @@ import (
 func OnInterrupt(fn func()) {
 	// deal with control+c,etc
 	signalChan := make(chan os.Signal, 1)
+	// controlling terminal close, daemon not exit   
+	signal.Ignore(syscall.SIGHUP)
 	signal.Notify(signalChan,
 		os.Interrupt,
 		os.Kill,
 		syscall.SIGALRM,
-		syscall.SIGHUP,
+		// syscall.SIGHUP,
 		syscall.SIGINT,
 		syscall.SIGTERM,
 		syscall.SIGQUIT)


### PR DESCRIPTION
I use cmd below to run weedfs in server.
``` shell
nohup ./weed -log_dir="./log/" volume -ip=10.144.152.250 -mserver="10.164.30.155:9333" -port=8887  -dir="./data0" -max=10000 &
```
when I close the terminal(i use Xshell), weedfs exit, too. I add the log and find weedfs receive signal "hangup", so I ignore syscall.SIGHUP