### PR TITLE
Go1.4.2 signal handling fix and Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+
+.clean:
+	go clean -i -v ./go/weed/
+
+.deps:
+	go get -d ./go/weed/
+
+.build: .deps
+	go build -v ./go/weed/
+
+all: .build


### PR DESCRIPTION
Since `signal.Ignore` doesn't seem to be present in 1.4.2 I've created an ignore channel to handle the SIGHUP.

Added a simple makefile as well.