### PR TITLE
collection name could be specified in url

### DIFF
--- a/go/weed/weed_server/filer_server_handlers.go
+++ b/go/weed/weed_server/filer_server_handlers.go
@@ -130,7 +130,11 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request) {
 	if replication == "" {
 		replication = fs.defaultReplication
 	}
-	assignResult, ae := operation.Assign(fs.master, 1, replication, fs.collection, query.Get("ttl"))
+	collection := query.Get("collection")
+	if collection == "" {
+		collection = fs.collection
+	}
+	assignResult, ae := operation.Assign(fs.master, 1, replication, collection, query.Get("ttl"))
 	if ae != nil {
 		glog.V(0).Infoln("failing to assign a file id", ae.Error())
 		writeJsonError(w, r, http.StatusInternalServerError, ae)


### PR DESCRIPTION
uploading file with filer service could specify the collection name in get/post field, if no collection specified, the default collection setting against the filer service will be used