### PR TITLE
use klauspost/crc32 instead of hash/crc32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: go
-go: 
+go:
  - 1.5
+ - 1.6
  - tip
 
 before_install:
@@ -9,6 +10,6 @@ before_install:
 
 install:
  - go get ./go/...
- 
+
 script:
  - go test ./go/...

--- a/go/storage/crc.go
+++ b/go/storage/crc.go
@@ -2,7 +2,7 @@ package storage
 
 import (
 	"fmt"
-	"hash/crc32"
+	"github.com/klauspost/crc32"
 
 	"github.com/chrislusf/seaweedfs/go/util"
 )


### PR DESCRIPTION
This package is a drop-in replacement for the standard library hash/crc32 package, that features SSE 4.2 optimizations on x64 platforms, for a 10x speedup.