### PR TITLE
faster ParseKeyHash

### DIFF
--- a/go/storage/needle.go
+++ b/go/storage/needle.go
@@ -218,7 +218,7 @@ func ParseKeyHash(key_hash_string string) (uint64, uint32, error) {
 	}
 	key_hash_bytes, khe := hex.DecodeString(key_hash_string)
 	key_hash_len := len(key_hash_bytes)
-	if khe != nil || key_hash_len <= 4 {
+	if khe != nil || key_hash_len <= 4 || key_hash_len > 12 {
 		glog.V(0).Infoln("Invalid key_hash", key_hash_string, "length:", key_hash_len, "error", khe)
 		return 0, 0, errors.New("Invalid key and hash:" + key_hash_string)
 	}

--- a/go/storage/needle_test.go
+++ b/go/storage/needle_test.go
@@ -1,0 +1,45 @@
+package storage
+
+import "testing"
+
+func TestParseKeyHash(t *testing.T) {
+	testcases := []struct {
+		KeyHash string
+		ID      uint64
+		Cookie  uint32
+		Err     bool
+	}{
+		// normal
+		{"4ed4c8116e41", 0x4ed4, 0xc8116e41, false},
+		// cookie with leading zeros
+		{"4ed401116e41", 0x4ed4, 0x01116e41, false},
+		// odd length
+		{"ed400116e41", 0xed4, 0x00116e41, false},
+		// uint
+		{"fed4c8114ed4c811f0116e41", 0xfed4c8114ed4c811, 0xf0116e41, false},
+		// err: too short
+		{"4ed4c811", 0, 0, true},
+		// err: too long
+		{"4ed4c8114ed4c8114ed4c8111", 0, 0, true},
+		// err: invalid character
+		{"helloworld", 0, 0, true},
+	}
+
+	for _, tc := range testcases {
+		if id, cookie, err := ParseKeyHash(tc.KeyHash); err != nil && !tc.Err {
+			t.Fatalf("Parse %s error: %v", tc.KeyHash, err)
+		} else if err == nil && tc.Err {
+			t.Fatalf("Parse %s expected error got nil", tc.KeyHash)
+		} else if id != tc.ID || cookie != tc.Cookie {
+			t.Fatalf("Parse %s wrong result. Expected: (%d, %d) got: (%d, %d)", tc.KeyHash, tc.ID, tc.Cookie, id, cookie)
+		}
+	}
+}
+
+func BenchmarkParseKeyHash(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		ParseKeyHash("4ed44ed44ed44ed4c8116e41")
+	}
+}


### PR DESCRIPTION
```
before:
BenchmarkParseKeyHash-4 10000000           241 ns/op          16 B/op          1 allocs/op

after:
BenchmarkParseKeyHash-4 20000000           111 ns/op           0 B/op          0 allocs/op
```