### PR TITLE
Fix Content-Disposition header

### DIFF
--- a/go/weed/weed_server/volume_server_handlers_read.go
+++ b/go/weed/weed_server/volume_server_handlers_read.go
@@ -197,7 +197,13 @@ func writeResponseContent(filename, mimeType string, rs io.ReadSeeker, w http.Re
 		w.Header().Set("Content-Type", mimeType)
 	}
 	if filename != "" {
-		w.Header().Set("Content-Disposition", `filename="`+fileNameEscaper.Replace(filename)+`"`)
+		contentDisposition := "inline"
+		if r.FormValue("dl") != "" {
+			if dl, _ := strconv.ParseBool(r.FormValue("dl")); dl {
+				contentDisposition = "attachment"
+			}
+		}
+		w.Header().Set("Content-Disposition", contentDisposition+`; filename="`+fileNameEscaper.Replace(filename)+`"`)
 	}
 	w.Header().Set("Accept-Ranges", "bytes")
 	if r.Method == "HEAD" {


### PR DESCRIPTION
Fixes **Content-Disposition** header as defined by RFC6266
Adds **dl=(0|1)** URI param to select inline (default) or attachment content disposition