### PR TITLE
fix bug when choosing the healthy master in filer service

### DIFF
--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -73,7 +73,10 @@ func NewFilerServer(r *http.ServeMux, ip string, port int, master string, dir st
 		glog.V(0).Infof("Filer server bootstraps with master %s", fs.getMasterNode())
 
 		//force initialize with all available master nodes
-		fs.masterNodes.FindMaster()
+		_, err := fs.masterNodes.FindMaster()
+		if err != nil {
+			glog.Fatalf("filer server failed to get master cluster info:%s", err.Error())
+		}
 
 		for {
 			glog.V(4).Infof("Filer server sending to master %s", fs.getMasterNode())
@@ -127,7 +130,7 @@ func (fs *FilerServer) detectHealthyMaster(masterNode string) (master string, e 
 			if e != nil {
 				continue
 			} else {
-				if e = checkMaster(masterNode); e == nil {
+				if e = checkMaster(master); e == nil {
 					break
 				}
 			}


### PR DESCRIPTION
This is an edge case
When the master cluster's status is not ready, filer should output fatal log e.g instead of go on running
```
I0630 17:27:04 41495 store.go:58] Failed listing masters on 100.107.5.2:9333: http://100.107.5.2:9333/cluster/status: 404 Not Found `
```
The reproduced step is:
1. restart master1, master2, master3 quickly(volume servers have been launched for a while)
2. start filer 1 and specify master1 in command option asap(while master 1's cluster status is not ready yet)
3. stop master1
Then the filer 1 will never get the master cluster's topo until master 1 is relaunched with available cluster status

And fix another bug in detectHealthyMaster func
