### PR TITLE
deleted needle does not need checksum verification(patch)

### DIFF
--- a/weed/storage/volume_checking.go
+++ b/weed/storage/volume_checking.go
@@ -21,6 +21,10 @@ func CheckVolumeDataIntegrity(v *Volume, indexFile *os.File) error {
 		return fmt.Errorf("readLastIndexEntry %s failed: %v", indexFile.Name(), e)
 	}
 	key, offset, size := idxFileEntry(lastIdxEntry)
+	//deleted index entry could not point to deleted needle
+	if offset == 0 || size == 0 {
+		return nil
+	}
 	if e = verifyNeedleIntegrity(v.dataFile, v.Version(), int64(offset)*NeedlePaddingSize, key, size); e != nil {
 		return fmt.Errorf("verifyNeedleIntegrity %s failed: %v", indexFile.Name(), e)
 	}

--- a/weed/storage/volume_checking.go
+++ b/weed/storage/volume_checking.go
@@ -22,7 +22,7 @@ func CheckVolumeDataIntegrity(v *Volume, indexFile *os.File) error {
 	}
 	key, offset, size := idxFileEntry(lastIdxEntry)
 	//deleted index entry could not point to deleted needle
-	if offset == 0 || size == 0 {
+	if offset == 0 {
 		return nil
 	}
 	if e = verifyNeedleIntegrity(v.dataFile, v.Version(), int64(offset)*NeedlePaddingSize, key, size); e != nil {

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -43,7 +43,6 @@ func (vl *VolumeLayout) RegisterVolume(v *storage.VolumeInfo, dn *DataNode) {
 	if _, ok := vl.vid2location[v.Id]; !ok {
 		vl.vid2location[v.Id] = NewVolumeLocationList()
 	}
-	vl.vid2location[v.Id].Set(dn)
 	glog.V(4).Infoln("volume", v.Id, "added to dn", dn.Id(), "len", vl.vid2location[v.Id].Length(), "copy", v.ReplicaPlacement.GetCopyCount())
 	if vl.vid2location[v.Id].Length() == vl.rp.GetCopyCount() && vl.isWritable(v) {
 		if _, ok := vl.oversizedVolumes[v.Id]; !ok {

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -43,6 +43,7 @@ func (vl *VolumeLayout) RegisterVolume(v *storage.VolumeInfo, dn *DataNode) {
 	if _, ok := vl.vid2location[v.Id]; !ok {
 		vl.vid2location[v.Id] = NewVolumeLocationList()
 	}
+	vl.vid2location[v.Id].Set(dn)
 	glog.V(4).Infoln("volume", v.Id, "added to dn", dn.Id(), "len", vl.vid2location[v.Id].Length(), "copy", v.ReplicaPlacement.GetCopyCount())
 	if vl.vid2location[v.Id].Length() == vl.rp.GetCopyCount() && vl.isWritable(v) {
 		if _, ok := vl.oversizedVolumes[v.Id]; !ok {


### PR DESCRIPTION
The deleted index entry format is below 
id          |   offset           | size
8Bytes     4 Bytes         4Bytes
offset and size value are both 0
If the last index entry of a specific index file is a deleted one,  we will bypass the needle verification.