### PR TITLE
if replicated volume has one copy in readonly mode at one node,it sho…

### DIFF
--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -79,6 +79,17 @@ func (dn *DataNode) GetVolumes() (ret []storage.VolumeInfo) {
 	return ret
 }
 
+func (dn *DataNode) GetVolumesById(id storage.VolumeId) (storage.VolumeInfo, error) {
+	dn.RLock()
+	defer dn.RUnlock()
+	v_info, ok := dn.volumes[id]
+	if ok {
+		return v_info, nil
+	} else {
+		return storage.VolumeInfo{}, fmt.Errorf("volumeInfo not found")
+	}
+}
+
 func (dn *DataNode) GetDataCenter() *DataCenter {
 	return dn.Parent().Parent().(*NodeImpl).value.(*DataCenter)
 }


### PR DESCRIPTION
…uld be removed from writable list

Disk fault or power-down may lead to the volume file in readonly mode at a specific machine. In this scenario, if the volume is a replicated one,  the sending heartbeat from different volume nodes to master node will switch between adding  it into and removing it from the master's writable list 

So I add a fix for above case

@chrislusf Chris, please help to review the code. 