### PR TITLE
Fix the filer connection of cassandra

### DIFF
--- a/weed/filer/cassandra_store/cassandra_store.go
+++ b/weed/filer/cassandra_store/cassandra_store.go
@@ -34,6 +34,7 @@ func NewCassandraStore(keyspace string, hosts ...string) (c *CassandraStore, err
 	c = &CassandraStore{}
 	        s := strings.Split(hosts, ",")
         if len(s) == 1 {
+		glog.V(0).Infof("Only one  cassandra node to connect!A Cluster is Proposed" )
                 c.cluster = gocql.NewCluster(hosts...)
         } else if len(s) > 1 {
                 c.cluster = gocql.NewCluster(s[0], s[1])

--- a/weed/filer/cassandra_store/cassandra_store.go
+++ b/weed/filer/cassandra_store/cassandra_store.go
@@ -34,7 +34,8 @@ func NewCassandraStore(keyspace string, hosts ...string) (c *CassandraStore, err
 	c = &CassandraStore{}
 	        s := strings.Split(hosts, ",")
         if len(s) == 1 {
-		glog.V(0).Infof("Only one  cassandra node to connect!A Cluster is Proposed" )
+
+		glog.V(2).Info("Only one  cassandra node to connect!A Cluster is Proposed!Now using:", string(hosts))
                 c.cluster = gocql.NewCluster(hosts...)
         } else if len(s) > 1 {
                 c.cluster = gocql.NewCluster(s[0], s[1])

--- a/weed/filer/cassandra_store/cassandra_store.go
+++ b/weed/filer/cassandra_store/cassandra_store.go
@@ -32,7 +32,12 @@ type CassandraStore struct {
 
 func NewCassandraStore(keyspace string, hosts ...string) (c *CassandraStore, err error) {
 	c = &CassandraStore{}
-	c.cluster = gocql.NewCluster(hosts...)
+	        s := strings.Split(hosts, ",")
+        if len(s) == 1 {
+                c.cluster = gocql.NewCluster(hosts...)
+        } else if len(s) > 1 {
+                c.cluster = gocql.NewCluster(s[0], s[1])
+        }
 	c.cluster.Keyspace = keyspace
 	c.cluster.Consistency = gocql.Quorum
 	c.session, err = c.cluster.CreateSession()

--- a/weed/filer/cassandra_store/cassandra_store.go
+++ b/weed/filer/cassandra_store/cassandra_store.go
@@ -30,13 +30,13 @@ type CassandraStore struct {
 	session *gocql.Session
 }
 
-func NewCassandraStore(keyspace string, hosts ...string) (c *CassandraStore, err error) {
+func NewCassandraStore(keyspace string, hosts string) (c *CassandraStore, err error) {
 	c = &CassandraStore{}
 	        s := strings.Split(hosts, ",")
         if len(s) == 1 {
 
 		glog.V(2).Info("Only one  cassandra node to connect!A Cluster is Proposed!Now using:", string(hosts))
-                c.cluster = gocql.NewCluster(hosts...)
+                c.cluster = gocql.NewCluster(hosts)
         } else if len(s) > 1 {
                 c.cluster = gocql.NewCluster(s[0], s[1])
         }

--- a/weed/filer/cassandra_store/cassandra_store.go
+++ b/weed/filer/cassandra_store/cassandra_store.go
@@ -34,8 +34,11 @@ func NewCassandraStore(keyspace string, hosts ...string) (c *CassandraStore, err
 	c = &CassandraStore{}
 	        s := strings.Split(hosts, ",")
         if len(s) == 1 {
+		fmt.Println("000")
                 c.cluster = gocql.NewCluster(hosts...)
         } else if len(s) > 1 {
+		fmt.Println("111",s[0])
+		fmt.Println("222",s[1])
                 c.cluster = gocql.NewCluster(s[0], s[1])
         }
 	c.cluster.Keyspace = keyspace

--- a/weed/filer/cassandra_store/cassandra_store.go
+++ b/weed/filer/cassandra_store/cassandra_store.go
@@ -2,7 +2,7 @@ package cassandra_store
 
 import (
 	"fmt"
-
+	"strings"
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/glog"
 
@@ -34,11 +34,8 @@ func NewCassandraStore(keyspace string, hosts ...string) (c *CassandraStore, err
 	c = &CassandraStore{}
 	        s := strings.Split(hosts, ",")
         if len(s) == 1 {
-		fmt.Println("000")
                 c.cluster = gocql.NewCluster(hosts...)
         } else if len(s) > 1 {
-		fmt.Println("111",s[0])
-		fmt.Println("222",s[1])
                 c.cluster = gocql.NewCluster(s[0], s[1])
         }
 	c.cluster.Keyspace = keyspace

--- a/weed/filer/cassandra_store/cassandra_store.go
+++ b/weed/filer/cassandra_store/cassandra_store.go
@@ -34,11 +34,10 @@ func NewCassandraStore(keyspace string, hosts string) (c *CassandraStore, err er
 	c = &CassandraStore{}
 	        s := strings.Split(hosts, ",")
         if len(s) == 1 {
-
 		glog.V(2).Info("Only one  cassandra node to connect!A Cluster is Proposed!Now using:", string(hosts))
                 c.cluster = gocql.NewCluster(hosts)
         } else if len(s) > 1 {
-                c.cluster = gocql.NewCluster(s[0], s[1])
+                c.cluster = gocql.NewCluster(s...)
         }
 	c.cluster.Keyspace = keyspace
 	c.cluster.Consistency = gocql.Quorum


### PR DESCRIPTION
Filer can use a cassandra cluster as the storage of metadata.
After the fix we can use more than one cassandra node for filer.

Due to the function `NewCluster` in gocql, now we support two cassandra nodes setting only