### PR TITLE
Return json data when content-type is "application/json"

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -74,7 +74,12 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 		lastFileName,
 		shouldDisplayLoadMore,
 	}
-	ui.StatusTpl.Execute(w, args)
+	
+	if strings.ToLower(r.Header.Get("Content-Type")) == "application/json" {
+		writeJsonQuiet(w, r, http.StatusOK, args)
+	} else {
+		ui.StatusTpl.Execute(w, args)
+	}
 }
 
 func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request, isGetMethod bool) {


### PR DESCRIPTION
Before #344, the filer will return json data, and cschiano make a template that render to html. But sometimes need json data, so I add some code will return json data when content-type is "application/json".