### PR TITLE
fix bug: upload big .gz file more than maxMB

### DIFF
--- a/weed/command/upload.go
+++ b/weed/command/upload.go
@@ -63,7 +63,7 @@ var cmdUpload = &Command{
 
 func runUpload(cmd *Command, args []string) bool {
 	secret := security.Secret(*upload.secretKey)
-	if len(cmdUpload.Flag.Args()) == 0 {
+	if len(args) == 0 {
 		if *upload.dir == "" {
 			return false
 		}

--- a/weed/operation/submit.go
+++ b/weed/operation/submit.go
@@ -92,18 +92,15 @@ func newFilePart(fullPathFilename string) (ret FilePart, err error) {
 	}
 	ret.Reader = fh
 
-	if fi, fiErr := fh.Stat(); fiErr != nil {
+	fi, fiErr := fh.Stat()
+	if fiErr != nil {
 		glog.V(0).Info("Failed to stat file:", fullPathFilename)
 		return ret, fiErr
-	} else {
-		ret.ModTime = fi.ModTime().UTC().Unix()
-		ret.FileSize = fi.Size()
 	}
+	ret.ModTime = fi.ModTime().UTC().Unix()
+	ret.FileSize = fi.Size()
 	ext := strings.ToLower(path.Ext(fullPathFilename))
 	ret.IsGzipped = ext == ".gz"
-	if ret.IsGzipped {
-		ret.FileName = fullPathFilename[0 : len(fullPathFilename)-3]
-	}
 	ret.FileName = fullPathFilename
 	if ext != "" {
 		ret.MimeType = mime.TypeByExtension(ext)


### PR DESCRIPTION
fixes #413. When chunking .gz file, chunked manifest file is marked as 'gzipped', but actually not gzipped. so if it's loaded, it will be ungziped, and then panic.