### PR TITLE
support additional header name-value pairs

### DIFF
--- a/weed/operation/submit.go
+++ b/weed/operation/submit.go
@@ -155,7 +155,7 @@ func (fi FilePart) Upload(maxMB int, master string, secret security.Secret) (ret
 			cm.DeleteChunks(master)
 		}
 	} else {
-		ret, e := Upload(fileUrl, baseName, fi.Reader, fi.IsGzipped, fi.MimeType, jwt)
+		ret, e := Upload(fileUrl, baseName, fi.Reader, fi.IsGzipped, fi.MimeType, nil, jwt)
 		if e != nil {
 			return 0, e
 		}
@@ -180,7 +180,7 @@ func upload_one_chunk(filename string, reader io.Reader, master,
 	fileUrl, fid := "http://"+ret.Url+"/"+ret.Fid, ret.Fid
 	glog.V(4).Info("Uploading part ", filename, " to ", fileUrl, "...")
 	uploadResult, uploadError := Upload(fileUrl, filename, reader, false,
-		"application/octet-stream", jwt)
+		"application/octet-stream", nil, jwt)
 	if uploadError != nil {
 		return fid, 0, uploadError
 	}
@@ -198,6 +198,6 @@ func upload_chunked_file_manifest(fileUrl string, manifest *ChunkManifest, jwt s
 	q := u.Query()
 	q.Set("cm", "true")
 	u.RawQuery = q.Encode()
-	_, e = Upload(u.String(), manifest.Name, bufReader, false, "application/json", jwt)
+	_, e = Upload(u.String(), manifest.Name, bufReader, false, "application/json", nil, jwt)
 	return e
 }

--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -36,13 +36,13 @@ func init() {
 
 var fileNameEscaper = strings.NewReplacer("\\", "\\\\", "\"", "\\\"")
 
-func Upload(uploadUrl string, filename string, reader io.Reader, isGzipped bool, mtype string, pairs []byte, jwt security.EncodedJwt) (*UploadResult, error) {
+func Upload(uploadUrl string, filename string, reader io.Reader, isGzipped bool, mtype string, pairMap map[string]string, jwt security.EncodedJwt) (*UploadResult, error) {
 	return upload_content(uploadUrl, func(w io.Writer) (err error) {
 		_, err = io.Copy(w, reader)
 		return
-	}, filename, isGzipped, mtype, pairs, jwt)
+	}, filename, isGzipped, mtype, pairMap, jwt)
 }
-func upload_content(uploadUrl string, fillBufferFunction func(w io.Writer) error, filename string, isGzipped bool, mtype string, pairs []byte, jwt security.EncodedJwt) (*UploadResult, error) {
+func upload_content(uploadUrl string, fillBufferFunction func(w io.Writer) error, filename string, isGzipped bool, mtype string, pairMap map[string]string, jwt security.EncodedJwt) (*UploadResult, error) {
 	body_buf := bytes.NewBufferString("")
 	body_writer := multipart.NewWriter(body_buf)
 	h := make(textproto.MIMEHeader)
@@ -58,13 +58,6 @@ func upload_content(uploadUrl string, fillBufferFunction func(w io.Writer) error
 	}
 	if jwt != "" {
 		h.Set("Authorization", "BEARER "+string(jwt))
-	}
-	pairMap := make(map[string]string)
-	if len(pairs) != 0 {
-		err := json.Unmarshal(pairs, &pairMap)
-		if err != nil {
-			glog.V(0).Infoln("Unmarshal pairs error:", err)
-		}
 	}
 
 	file_writer, cp_err := body_writer.CreatePart(h)

--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -86,7 +86,7 @@ func submitForClientHandler(w http.ResponseWriter, r *http.Request, masterUrl st
 	}
 
 	debug("parsing upload file...")
-	fname, data, mimeType, pairs, isGzipped, lastModified, _, _, pe := storage.ParseUpload(r)
+	fname, data, mimeType, pairMap, isGzipped, lastModified, _, _, pe := storage.ParseUpload(r)
 	if pe != nil {
 		writeJsonError(w, r, http.StatusBadRequest, pe)
 		return
@@ -112,7 +112,7 @@ func submitForClientHandler(w http.ResponseWriter, r *http.Request, masterUrl st
 	}
 
 	debug("upload file to store", url)
-	uploadResult, err := operation.Upload(url, fname, bytes.NewReader(data), isGzipped, mimeType, pairs, jwt)
+	uploadResult, err := operation.Upload(url, fname, bytes.NewReader(data), isGzipped, mimeType, pairMap, jwt)
 	if err != nil {
 		writeJsonError(w, r, http.StatusInternalServerError, err)
 		return

--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -86,7 +86,7 @@ func submitForClientHandler(w http.ResponseWriter, r *http.Request, masterUrl st
 	}
 
 	debug("parsing upload file...")
-	fname, data, mimeType, isGzipped, lastModified, _, _, pe := storage.ParseUpload(r)
+	fname, data, mimeType, pairs, isGzipped, lastModified, _, _, pe := storage.ParseUpload(r)
 	if pe != nil {
 		writeJsonError(w, r, http.StatusBadRequest, pe)
 		return
@@ -112,7 +112,7 @@ func submitForClientHandler(w http.ResponseWriter, r *http.Request, masterUrl st
 	}
 
 	debug("upload file to store", url)
-	uploadResult, err := operation.Upload(url, fname, bytes.NewReader(data), isGzipped, mimeType, jwt)
+	uploadResult, err := operation.Upload(url, fname, bytes.NewReader(data), isGzipped, mimeType, pairs, jwt)
 	if err != nil {
 		writeJsonError(w, r, http.StatusInternalServerError, err)
 		return

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -13,10 +13,9 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"strings"
-
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/glog"

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -15,13 +15,14 @@ import (
 	"net/url"
 	"strings"
 
+	"path"
+	"strconv"
+
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/operation"
 	"github.com/chrislusf/seaweedfs/weed/storage"
 	"github.com/chrislusf/seaweedfs/weed/util"
-	"path"
-	"strconv"
 )
 
 type FilerPostResult struct {
@@ -112,7 +113,7 @@ func (fs *FilerServer) multipartUploadAnalyzer(w http.ResponseWriter, r *http.Re
 	if r.Method == "PUT" {
 		buf, _ := ioutil.ReadAll(r.Body)
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
-		fileName, _, _, _, _, _, _, pe := storage.ParseUpload(r)
+		fileName, _, _, _, _, _, _, _, pe := storage.ParseUpload(r)
 		if pe != nil {
 			glog.V(0).Infoln("failing to parse post body", pe.Error())
 			writeJsonError(w, r, http.StatusInternalServerError, pe)
@@ -521,7 +522,7 @@ func (fs *FilerServer) doUpload(urlLocation string, w http.ResponseWriter, r *ht
 	err = nil
 
 	ioReader := ioutil.NopCloser(bytes.NewBuffer(chunkBuf))
-	uploadResult, uploadError := operation.Upload(urlLocation, fileName, ioReader, false, contentType, fs.jwt(fileId))
+	uploadResult, uploadError := operation.Upload(urlLocation, fileName, ioReader, false, contentType, nil, fs.jwt(fileId))
 	if uploadResult != nil {
 		glog.V(0).Infoln("Chunk upload result. Name:", uploadResult.Name, "Fid:", fileId, "Size:", uploadResult.Size)
 	}

--- a/weed/server/volume_server_handlers_read.go
+++ b/weed/server/volume_server_handlers_read.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"encoding/json"
+
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/images"
 	"github.com/chrislusf/seaweedfs/weed/operation"
@@ -93,6 +95,17 @@ func (vs *VolumeServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	w.Header().Set("Etag", etag)
+
+	if n.HasPairs() {
+		pairMap := make(map[string]string)
+		err = json.Unmarshal(n.Pairs, &pairMap)
+		if err != nil {
+			glog.V(0).Infoln("Unmarshal pairs error:", err)
+		}
+		for k, v := range pairMap {
+			w.Header().Set(k, v)
+		}
+	}
 
 	if vs.tryHandleChunkedFile(n, filename, w, r) {
 		return

--- a/weed/storage/needle_read_write.go
+++ b/weed/storage/needle_read_write.go
@@ -16,6 +16,7 @@ const (
 	FlagHasMime             = 0x04
 	FlagHasLastModifiedDate = 0x08
 	FlagHasTtl              = 0x10
+	FlagHasPairs            = 0x20
 	FlagIsChunkManifest     = 0x80
 	LastModifiedBytesLength = 5
 	TtlBytesLength          = 2
@@ -78,6 +79,9 @@ func (n *Needle) Append(w io.Writer, version Version) (size uint32, actualSize i
 			if n.HasTtl() {
 				n.Size = n.Size + TtlBytesLength
 			}
+			if n.HasPairs() {
+				n.Size += 2 + uint32(n.PairsSize)
+			}
 		} else {
 			n.Size = 0
 		}
@@ -128,6 +132,15 @@ func (n *Needle) Append(w io.Writer, version Version) (size uint32, actualSize i
 					return
 				}
 			}
+			if n.HasPairs() {
+				util.Uint16toBytes(header[0:2], n.PairsSize)
+				if _, err = w.Write(header[0:2]); err != nil {
+					return
+				}
+				if _, err = w.Write(n.Pairs); err != nil {
+					return
+				}
+			}
 		}
 		padding := NeedlePaddingSize - ((NeedleHeaderSize + n.Size + NeedleChecksumSize) % NeedlePaddingSize)
 		util.Uint32toBytes(header[0:NeedleChecksumSize], n.Checksum.Value())
@@ -141,8 +154,9 @@ func (n *Needle) Append(w io.Writer, version Version) (size uint32, actualSize i
 }
 
 func ReadNeedleBlob(r *os.File, offset int64, size uint32) (dataSlice []byte, block *Block, err error) {
-	padding := NeedlePaddingSize - ((NeedleHeaderSize + size + NeedleChecksumSize) % NeedlePaddingSize)
-	readSize := NeedleHeaderSize + size + NeedleChecksumSize + padding
+	NeedleWithoutPaddingSize := NeedleHeaderSize + size + NeedleChecksumSize
+	padding := NeedlePaddingSize - (NeedleWithoutPaddingSize % NeedlePaddingSize)
+	readSize := NeedleWithoutPaddingSize + padding
 	return getBytesForFileBlock(r, offset, int(readSize))
 }
 
@@ -212,6 +226,13 @@ func (n *Needle) readNeedleDataVersion2(bytes []byte) {
 	if index < lenBytes && n.HasTtl() {
 		n.Ttl = LoadTTLFromBytes(bytes[index : index+TtlBytesLength])
 		index = index + TtlBytesLength
+	}
+	if index < lenBytes && n.HasPairs() {
+		n.PairsSize = util.BytesToUint16(bytes[index : index+2])
+		index += 2
+		end := index + int(n.PairsSize)
+		n.Pairs = bytes[index:end]
+		index = end
 	}
 }
 
@@ -295,4 +316,12 @@ func (n *Needle) IsChunkedManifest() bool {
 
 func (n *Needle) SetIsChunkManifest() {
 	n.Flags = n.Flags | FlagIsChunkManifest
+}
+
+func (n *Needle) HasPairs() bool {
+	return n.Flags&FlagHasPairs != 0
+}
+
+func (n *Needle) SetHasPairs() {
+	n.Flags = n.Flags | FlagHasPairs
 }

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -303,6 +303,7 @@ func (s *Store) Write(i VolumeId, n *Needle) (size uint32, err error) {
 			err = fmt.Errorf("Volume %d is read only", i)
 			return
 		}
+		// TODO: count needle size ahead
 		if MaxPossibleVolumeSize >= v.ContentSize()+uint64(size) {
 			size, err = v.writeNeedle(n)
 		} else {

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -2,13 +2,13 @@ package topology
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
-
-	"net/url"
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/operation"
@@ -55,9 +55,18 @@ func ReplicatedWrite(masterNode string, s *storage.Store,
 					q.Set("cm", "true")
 				}
 				u.RawQuery = q.Encode()
+
+				pairMap := make(map[string]string)
+				if needle.HasPairs() {
+					err := json.Unmarshal(needle.Pairs, &pairMap)
+					if err != nil {
+						glog.V(0).Infoln("Unmarshal pairs error:", err)
+					}
+				}
+
 				_, err := operation.Upload(u.String(),
 					string(needle.Name), bytes.NewReader(needle.Data), needle.IsGzipped(), string(needle.Mime),
-					needle.Pairs, jwt)
+					pairMap, jwt)
 				return err
 			}); err != nil {
 				ret = 0

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -57,7 +57,7 @@ func ReplicatedWrite(masterNode string, s *storage.Store,
 				u.RawQuery = q.Encode()
 				_, err := operation.Upload(u.String(),
 					string(needle.Name), bytes.NewReader(needle.Data), needle.IsGzipped(), string(needle.Mime),
-					jwt)
+					needle.Pairs, jwt)
 				return err
 			}); err != nil {
 				ret = 0


### PR DESCRIPTION
The name of pairs must begin with 'Seaweed-'. Common use cases have been tested, other than some API I'm unfamiliar with, such as 'Filer server'.