### PR TITLE
Fix:  the maximum-length character exceed 255

### DIFF
--- a/weed/filer/mysql_store/mysql_store.go
+++ b/weed/filer/mysql_store/mysql_store.go
@@ -184,7 +184,7 @@ func (s *MySqlStore) Close() {
 var createTable = `
 CREATE TABLE IF NOT EXISTS %s (
   id bigint(20) NOT NULL AUTO_INCREMENT,
-  uriPath char(256) NOT NULL DEFAULT "" COMMENT 'http uriPath',
+  uriPath char(255) NOT NULL DEFAULT "" COMMENT 'http uriPath',
   fid char(36) NOT NULL DEFAULT "" COMMENT 'seaweedfs fid',
   createTime int(10) NOT NULL DEFAULT 0 COMMENT 'createdTime in unix timestamp',
   updateTime int(10) NOT NULL DEFAULT 0 COMMENT 'updatedTime in unix timestamp',


### PR DESCRIPTION
The length of a CHAR column is fixed to the length that you declare when you create the table. The length can be any value from 0 to 255. When CHAR values are stored, they are right-padded with spaces to the specified length. 

see https://dev.mysql.com/doc/refman/5.7/en/char.html