### PR TITLE
Fix panic error when target collection is not exist.

### DIFF
--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -116,6 +116,9 @@ func (t *Topology) GetVolumeLayout(collectionName string, rp *storage.ReplicaPla
 
 func (t *Topology) FindCollection(collectionName string) (*Collection, bool) {
 	c, hasCollection := t.collectionMap.Find(collectionName)
+	if !hasCollection {
+		return nil, false
+	}
 	return c.(*Collection), hasCollection
 }
 


### PR DESCRIPTION
Fix: interface conversion: interface {} is nil, not *topology.Collection.

```
2017/07/14 11:49:54 http: panic serving 172.20.0.1:51100: interface conversion: interface {} is nil, not *topology.Collection
net/http.(*conn).serve.func1(0xc4200be8c0)
        /home/travis/.gimme/versions/go/src/net/http/server.go:1693 +0xd0
panic(0xb8ce60, 0xc4203ef100)
        /home/travis/.gimme/versions/go/src/runtime/panic.go:489 +0x25a
github.com/chrislusf/seaweedfs/weed/topology.(*Topology).FindCollection(0xc4201e76c0, 0xc4202de5bb, 0x24, 0xc4202de5bb, 0x24)
        /home/travis/gopath/src/github.com/chrislusf/seaweedfs/weed/topology/topology.go:119 +0x92
github.com/chrislusf/seaweedfs/weed/server.(*MasterServer).collectionDeleteHandler(0xc4201e4400, 0x1080380, 0xc4202da620, 0xc420213800)
        /home/travis/gopath/src/github.com/chrislusf/seaweedfs/weed/server/master_server_handlers_admin.go:17 +0x7e
github.com/chrislusf/seaweedfs/weed/server.(*MasterServer).(github.com/chrislusf/seaweedfs/weed/server.collectionDeleteHandler)-fm(0x1080380, 0xc4202da620, 0xc420213800)
        /home/travis/gopath/src/github.com/chrislusf/seaweedfs/weed/server/master_server.go:71 +0x48
github.com/chrislusf/seaweedfs/weed/server.(*MasterServer).proxyToLeader.func1(0x1080380, 0xc4202da620, 0xc420213800)
        /home/travis/gopath/src/github.com/chrislusf/seaweedfs/weed/server/master_server.go:106 +0x53e
net/http.HandlerFunc.ServeHTTP(0xc4200b6740, 0x1080380, 0xc4202da620, 0xc420213800)
        /home/travis/.gimme/versions/go/src/net/http/server.go:1914 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc4201cc960, 0x1080380, 0xc4202da620, 0xc420213800)
        /home/travis/gopath/src/github.com/gorilla/mux/mux.go:114 +0xdc
net/http.serverHandler.ServeHTTP(0xc4201e7ba0, 0x1080380, 0xc4202da620, 0xc420213600)
        /home/travis/.gimme/versions/go/src/net/http/server.go:2595 +0xb4
net/http.(*conn).serve(0xc4200be8c0, 0x1080e80, 0xc4203eee40)
        /home/travis/.gimme/versions/go/src/net/http/server.go:1797 +0x71d
created by net/http.(*Server).Serve
        /home/travis/.gimme/versions/go/src/net/http/server.go:2696 +0x288

```