### PR TITLE
(fix #543)added response body to error when util.Post encounter 4xx response

### DIFF
--- a/weed/util/http_util.go
+++ b/weed/util/http_util.go
@@ -48,10 +48,14 @@ func Post(url string, values url.Values) ([]byte, error) {
 		return nil, err
 	}
 	defer r.Body.Close()
-	if r.StatusCode >= 400 {
-		return nil, fmt.Errorf("%s: %s", url, r.Status)
-	}
 	b, err := ioutil.ReadAll(r.Body)
+	if r.StatusCode >= 400 {
+		if err != nil {
+			return nil, fmt.Errorf("%s: %d - %s", url, r.StatusCode, string(b))
+		} else {
+			return nil, fmt.Errorf("%s: %s", url, r.Status)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
to fix #543 , I make some changes in util.Post, make it combine response body into error when encountered 4xx or 5xx statusCode. So that benchmark command can report more accurate infos like 'No free volumes left' rather than a simple '404 Not Found'