### PR TITLE
filer: fixup print error message when make new directory

### DIFF
--- a/weed/filer/embedded_filer/directory_in_map.go
+++ b/weed/filer/embedded_filer/directory_in_map.go
@@ -167,7 +167,7 @@ func (dm *DirectoryManagerInMap) findDirectory(dirPath string) (*DirectoryEntryI
 		if sub, ok := dir.getChild(parts[i]); ok {
 			dir = sub
 		} else {
-			return dm.Root, fmt.Errorf("Directory %s Not Found", dirPath)
+			return dm.Root, filer.ErrNotFound
 		}
 	}
 	return dir, nil


### PR DESCRIPTION
Current filer's post handler prints error message when there is no existing directories in the file path.

```
	// also delete the old fid unless PUT operation
	if r.Method != "PUT" {
		if oldFid, err := fs.filer.FindFile(path); err == nil {
			operation.DeleteFile(fs.getMasterNode(), oldFid, fs.jwt(oldFid))
		} else if err != nil && err != filer.ErrNotFound {
			glog.V(0).Infof("error %v occur when finding %s in filer store", err, path)
		}
	}
```

The filer server code designed to not print error message in this situation. 
However the FindFile() method returns it's own declared error message instead of filer.ErrNotFound so it wasn't work. 
I changed to return filer.ErrNotFound.