### PR TITLE
some minor fixes to docker/Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,10 @@
 FROM frolvlad/alpine-glibc:alpine-3.5
 
-RUN apk add --no-cache --virtual=build-dependencies --update curl wget ca-certificates && \
-    wget -P /tmp https://github.com/$(curl -s -L https://github.com/chrislusf/seaweedfs/releases/latest | egrep -o '/chrislusf/seaweedfs/releases/download/.*/linux_amd64.tar.gz') && \
+# Tried to use curl only (curl -o /tmp/linux_amd64.tar.gz ...), however it turned out that the following tar command failed with "gzip: stdin: not in gzip format"
+RUN apk add --no-cache --virtual build-dependencies --update wget curl ca-certificates && \
+    wget -P /tmp https://github.com/$(curl -s -L https://github.com/chrislusf/seaweedfs/releases/latest | egrep -o 'chrislusf/seaweedfs/releases/download/.*/linux_amd64.tar.gz') && \
     tar -C /usr/bin/ -xzvf /tmp/linux_amd64.tar.gz && \
-    apk del curl wget ca-certificates build-dependencies && \
+    apk del build-dependencies && \
     rm -rf /tmp/*
 
 EXPOSE 8080


### PR DESCRIPTION
According to the information from https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md, "--virtual build-dependencies" is the right form.
"curl wget ca-certificates" are under the group "build-dependencies", so "apk del build-dependencies" should suffice. 
"...egrep -o '/chrislusf/seaweedfs/..." should be "...egrep -o 'chrislusf/seaweedfs/...", though one more slash does not cause problems.
Tried to use curl only (curl -o /tmp/linux_amd64.tar.gz ...), however it turned out that the following tar command failed with "gzip: stdin: not in gzip format" prompt. I now understand why you use both "curl" and "wget"