### PR TITLE
extend export command to show tombstone + change output format to CSV

### DIFF
--- a/weed/server/volume_server_handlers_write.go
+++ b/weed/server/volume_server_handlers_write.go
@@ -9,6 +9,8 @@ import (
 	"github.com/chrislusf/seaweedfs/weed/operation"
 	"github.com/chrislusf/seaweedfs/weed/storage"
 	"github.com/chrislusf/seaweedfs/weed/topology"
+	"time"
+	"strconv"
 )
 
 func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
@@ -87,6 +89,13 @@ func (vs *VolumeServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
 		count = chunkManifest.Size
 	}
 
+	n.LastModified = uint64(time.Now().Unix())
+	if len(r.FormValue("time")) > 0 {
+		modifiedTime, err := strconv.ParseInt(r.FormValue("time"), 10, 64)
+		if err == nil {
+			n.LastModified = uint64(modifiedTime)
+		}
+	}
 	_, err := topology.ReplicatedDelete(vs.GetMasterNode(), vs.store, volumeId, n, r)
 
 	if err == nil {
@@ -103,6 +112,7 @@ func (vs *VolumeServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
 func (vs *VolumeServer) batchDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 	var ret []operation.DeleteResult
+	now := uint64(time.Now().Unix())
 	for _, fid := range r.Form["fid"] {
 		vid, id_cookie, err := operation.ParseFileId(fid)
 		if err != nil {
@@ -144,6 +154,9 @@ func (vs *VolumeServer) batchDeleteHandler(w http.ResponseWriter, r *http.Reques
 			glog.V(0).Infoln("deleting", fid, "with unmaching cookie from ", r.RemoteAddr, "agent", r.UserAgent())
 			return
 		}
+
+		n.LastModified = now
+
 		if size, err := vs.store.Delete(volumeId, n); err != nil {
 			ret = append(ret, operation.DeleteResult{
 				Fid:    fid,

--- a/weed/storage/needle.go
+++ b/weed/storage/needle.go
@@ -262,3 +262,7 @@ func ParseKeyHash(key_hash_string string) (uint64, uint32, error) {
 	}
 	return key, uint32(hash), nil
 }
+
+func (n *Needle) LastModifiedString() string {
+	return time.Unix(int64(n.LastModified), 0).Format("2006-01-02T15:04:05")
+}

--- a/weed/storage/volume.go
+++ b/weed/storage/volume.go
@@ -80,6 +80,26 @@ func (v *Volume) ContentSize() uint64 {
 	return v.nm.ContentSize()
 }
 
+func (v *Volume) DeletedSize() uint64 {
+	return v.nm.DeletedSize()
+}
+
+func (v *Volume) FileCount() int {
+	return v.nm.FileCount()
+}
+
+func (v *Volume) DeletedCount() int {
+	return v.nm.DeletedCount()
+}
+
+func (v *Volume) LastModifiedTime() uint64 {
+	return v.lastModifiedTime
+}
+
+func (v *Volume) LastModifiedString() string {
+	return time.Unix(int64(v.lastModifiedTime), 0).Format("2006-01-02T15:04:05")
+}
+
 // volume is expired if modified time + volume ttl < now
 // except when volume is empty
 // or when the volume does not have a ttl

--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -8,6 +8,14 @@ import (
 	"github.com/chrislusf/seaweedfs/weed/glog"
 )
 
+func LoadVolume(dirname string, collection string, id VolumeId, needleMapKind NeedleMapType) (v *Volume, e error) {
+	v = &Volume{dir: dirname, Collection: collection, Id: id}
+	v.SuperBlock = SuperBlock{}
+	v.needleMapKind = needleMapKind
+	e = v.load(true, false, needleMapKind, 0)
+	return
+}
+
 func loadVolumeWithoutIndex(dirname string, collection string, id VolumeId, needleMapKind NeedleMapType) (v *Volume, e error) {
 	v = &Volume{dir: dirname, Collection: collection, Id: id}
 	v.SuperBlock = SuperBlock{}

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -102,7 +102,7 @@ func ReplicatedDelete(masterNode string, store *storage.Store,
 	if needToReplicate { //send to other replica locations
 		if r.FormValue("type") != "replicate" {
 			if err = distributedOperation(masterNode, store, volumeId, func(location operation.Location) error {
-				return util.Delete("http://"+location.Url+r.URL.Path+"?type=replicate", jwt)
+				return util.Delete(fmt.Sprintf("http://%s%s?type=replicate&time=%d", location.Url, r.URL.Path, n.LastModified), jwt)
 			}); err != nil {
 				ret = 0
 			}


### PR DESCRIPTION
What do you think about that?
Exporting modification times + tombstone information may be pretty helpful when building external tools like sync/repair scripts
If you don't want to break BC, we could introduce an option to output CSV. I think for bulk operations, CSV is better suited as it is more dense and doesn't repeat the key names in every row.