### PR TITLE
Store and replicate timestamp of file deletion in tombstone marker

### DIFF
--- a/weed/server/volume_server_handlers_write.go
+++ b/weed/server/volume_server_handlers_write.go
@@ -9,6 +9,8 @@ import (
 	"github.com/chrislusf/seaweedfs/weed/operation"
 	"github.com/chrislusf/seaweedfs/weed/storage"
 	"github.com/chrislusf/seaweedfs/weed/topology"
+	"time"
+	"strconv"
 )
 
 func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
@@ -87,6 +89,13 @@ func (vs *VolumeServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
 		count = chunkManifest.Size
 	}
 
+	n.LastModified = uint64(time.Now().Unix())
+	if len(r.FormValue("time")) > 0 {
+		modifiedTime, err := strconv.ParseInt(r.FormValue("time"), 10, 64)
+		if err == nil {
+			n.LastModified = uint64(modifiedTime)
+		}
+	}
 	_, err := topology.ReplicatedDelete(vs.GetMasterNode(), vs.store, volumeId, n, r)
 
 	if err == nil {
@@ -103,6 +112,7 @@ func (vs *VolumeServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
 func (vs *VolumeServer) batchDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 	var ret []operation.DeleteResult
+	now := uint64(time.Now().Unix())
 	for _, fid := range r.Form["fid"] {
 		vid, id_cookie, err := operation.ParseFileId(fid)
 		if err != nil {
@@ -144,6 +154,9 @@ func (vs *VolumeServer) batchDeleteHandler(w http.ResponseWriter, r *http.Reques
 			glog.V(0).Infoln("deleting", fid, "with unmaching cookie from ", r.RemoteAddr, "agent", r.UserAgent())
 			return
 		}
+
+		n.LastModified = now
+
 		if size, err := vs.store.Delete(volumeId, n); err != nil {
 			ret = append(ret, operation.DeleteResult{
 				Fid:    fid,

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -102,7 +102,7 @@ func ReplicatedDelete(masterNode string, store *storage.Store,
 	if needToReplicate { //send to other replica locations
 		if r.FormValue("type") != "replicate" {
 			if err = distributedOperation(masterNode, store, volumeId, func(location operation.Location) error {
-				return util.Delete("http://"+location.Url+r.URL.Path+"?type=replicate", jwt)
+				return util.Delete(fmt.Sprintf("http://%s%s?type=replicate&time=%d", location.Url, r.URL.Path, n.LastModified), jwt)
 			}); err != nil {
 				ret = 0
 			}


### PR DESCRIPTION
I pulled out that of the recent PR. It's necessary for a proper repair / sync tool