### PR TITLE
Fix #568, avoid redirect when joining member

### DIFF
--- a/weed/compress/delta_binary_pack32.go
+++ b/weed/compress/delta_binary_pack32.go
@@ -1,8 +1,8 @@
 package compress
 
 import (
-	"github.com/reducedb/encoding/cursor"
-	"github.com/reducedb/encoding/delta/bp32"
+	"github.com/dataence/encoding/cursor"
+	"github.com/dataence/encoding/delta/bp32"
 )
 
 // Compress compresses in[]int32 to out[]int32


### PR DESCRIPTION
When adding a new member, query it's leader firstly, then send join request to the leader server directly, this could avoid occurring redirect in some cases.