### PR TITLE
fix leveldb mount bug

### DIFF
--- a/weed/storage/disk_location.go
+++ b/weed/storage/disk_location.go
@@ -164,11 +164,11 @@ func (l *DiskLocation) UnloadVolume(vid VolumeId) error {
 	l.Lock()
 	defer l.Unlock()
 
-	_, ok := l.volumes[vid]
+	v, ok := l.volumes[vid]
 	if !ok {
 		return fmt.Errorf("Volume not loaded, VolumeId: %d", vid)
 	}
-	l.volumes[vid].Close()
+	v.Close()
 	delete(l.volumes, vid)
 	return nil
 }

--- a/weed/storage/disk_location.go
+++ b/weed/storage/disk_location.go
@@ -168,6 +168,7 @@ func (l *DiskLocation) UnloadVolume(vid VolumeId) error {
 	if !ok {
 		return fmt.Errorf("Volume not loaded, VolumeId: %d", vid)
 	}
+	l.volumes[vid].Close()
 	delete(l.volumes, vid)
 	return nil
 }


### PR DESCRIPTION
index--->leveldb

operation:

unmount volume(vid=3)
mount volume(vid=3)
error:
I0502 16:02:19 03815 disk_location.go:59] new volume 3.dat error resource temporarily unavailable

fix:

add l.volumes[vid].close() in file storage/disk_location.go line 171 before delete(l.volumes, vid);