### PR TITLE
bugfix:check Directory attr  before create it

### DIFF
--- a/weed/filer2/filer.go
+++ b/weed/filer2/filer.go
@@ -80,6 +80,8 @@ func (f *Filer) CreateEntry(entry *Entry) error {
 			if mkdirErr != nil {
 				return fmt.Errorf("mkdir %s: %v", dirPath, mkdirErr)
 			}
+		} else if !dirEntry.IsDirectory() {
+			return fmt.Errorf("%s is a file", dirPath)
 		}
 
 		// cache the directory entry


### PR DESCRIPTION
when create a file use filer api,i would create every Directory the file need, but if there exist a file have the same name with the Directory, the filer will ignore it.that lead to some confusion