### PR TITLE
Update volume_server_handlers_read.go

### DIFF
--- a/weed/server/volume_server_handlers_read.go
+++ b/weed/server/volume_server_handlers_read.go
@@ -185,6 +185,9 @@ func (vs *VolumeServer) tryHandleChunkedFile(n *storage.Needle, fileName string,
 
 func conditionallyResizeImages(originalDataReaderSeeker io.ReadSeeker, ext string, r *http.Request) io.ReadSeeker {
 	rs := originalDataReaderSeeker
+	if len(ext) > 0 {
+		ext = strings.ToLower(ext)
+	}
 	if ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".gif" {
 		width, height := 0, 0
 		if r.FormValue("width") != "" {


### PR DESCRIPTION
当上传一个图片的后缀是大写字母，如，DSG_001.JPG的时候，ext就是.JPG，从而导致判断失效