### PR TITLE
change log_dir to logdir for the "flag redefined:log_dir" error when use another package with "github.com/golang/glog"

### DIFF
--- a/weed/glog/glog.go
+++ b/weed/glog/glog.go
@@ -46,7 +46,7 @@
 //	-stderrthreshold=ERROR
 //		Log events at or above this severity are logged to standard
 //		error as well as to files.
-//	-log_dir=""
+//	-logdir=""
 //		Log files will be written to this directory instead of the
 //		default temporary directory.
 //

--- a/weed/glog/glog_file.go
+++ b/weed/glog/glog_file.go
@@ -38,7 +38,7 @@ var logDirs []string
 
 // If non-empty, overrides the choice of directory in which to write logs.
 // See createLogDirs for the full list of possible destinations.
-var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
+var logDir = flag.String("logdir", "", "If non-empty, write log files in this directory")
 
 func createLogDirs() {
 	if *logDir != "" {


### PR DESCRIPTION
change log_dir to logdir for the "flag redefined:log_dir" error when use another package with "github.com/golang/glog"