### PR TITLE
fix needle Append return offset to avoid uint32 overflow

### DIFF
--- a/unmaintained/fix_dat/fix_dat.go
+++ b/unmaintained/fix_dat/fix_dat.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/storage"
-	"github.com/chrislusf/seaweedfs/weed/util"
 	"github.com/chrislusf/seaweedfs/weed/storage/types"
+	"github.com/chrislusf/seaweedfs/weed/util"
 )
 
 var (
@@ -63,7 +63,7 @@ func main() {
 
 	iterateEntries(datFile, indexFile, func(n *storage.Needle, offset int64) {
 		fmt.Printf("needle id=%v name=%s size=%d dataSize=%d\n", n.Id, string(n.Name), n.Size, n.DataSize)
-		s, _, e := n.Append(newDatFile, superBlock.Version())
+		_, s, _, e := n.Append(newDatFile, superBlock.Version())
 		fmt.Printf("size %d error %v\n", s, e)
 	})
 

--- a/unmaintained/see_dat/see_dat.go
+++ b/unmaintained/see_dat/see_dat.go
@@ -12,21 +12,31 @@ var (
 	volumeId         = flag.Int("volumeId", -1, "a volume id. The volume should already exist in the dir. The volume index file should not exist.")
 )
 
+type VolumeFileScanner4SeeDat struct {
+	version storage.Version
+}
+
+func (scanner *VolumeFileScanner4SeeDat) VisitSuperBlock(superBlock storage.SuperBlock) error {
+	scanner.version = superBlock.Version()
+	return nil
+
+}
+func (scanner *VolumeFileScanner4SeeDat) ReadNeedleBody() bool {
+	return false
+}
+
+func (scanner *VolumeFileScanner4SeeDat) VisitNeedle(n *storage.Needle, offset int64) error {
+	glog.V(0).Infof("%d,%s%x offset %d size %d cookie %x", *volumeId, n.Id, n.Cookie, offset, n.Size, n.Cookie)
+	return nil
+}
+
 func main() {
 	flag.Parse()
 
-	var version storage.Version
 	vid := storage.VolumeId(*volumeId)
-	err := storage.ScanVolumeFile(*volumePath, *volumeCollection, vid,
-		storage.NeedleMapInMemory,
-		func(superBlock storage.SuperBlock) error {
-			version = superBlock.Version()
-			return nil
-		}, false, func(n *storage.Needle, offset int64) error {
-			glog.V(0).Infof("%d,%s%x offset %d size %d cookie %x",
-				*volumeId, n.Id, n.Cookie, offset, n.Size, n.Cookie)
-			return nil
-		})
+
+	scanner := &VolumeFileScanner4SeeDat{}
+	err := storage.ScanVolumeFile(*volumePath, *volumeCollection, vid, storage.NeedleMapInMemory, scanner)
 	if err != nil {
 		glog.Fatalf("Reading Volume File [ERROR] %s\n", err)
 	}

--- a/weed/command/export.go
+++ b/weed/command/export.go
@@ -84,6 +84,62 @@ func printNeedle(vid storage.VolumeId, n *storage.Needle, version storage.Versio
 	)
 }
 
+type VolumeFileScanner4Export struct {
+	version   storage.Version
+	counter   int
+	needleMap *storage.NeedleMap
+	vid       storage.VolumeId
+}
+
+func (scanner *VolumeFileScanner4Export) VisitSuperBlock(superBlock storage.SuperBlock) error {
+	scanner.version = superBlock.Version()
+	return nil
+
+}
+func (scanner *VolumeFileScanner4Export) ReadNeedleBody() bool {
+	return true
+}
+
+func (scanner *VolumeFileScanner4Export) VisitNeedle(n *storage.Needle, offset int64) error {
+	needleMap := scanner.needleMap
+	vid := scanner.vid
+
+	nv, ok := needleMap.Get(n.Id)
+	glog.V(3).Infof("key %d offset %d size %d disk_size %d gzip %v ok %v nv %+v",
+		n.Id, offset, n.Size, n.DiskSize(scanner.version), n.IsGzipped(), ok, nv)
+	if ok && nv.Size > 0 && int64(nv.Offset)*types.NeedlePaddingSize == offset {
+		if newerThanUnix >= 0 && n.HasLastModifiedDate() && n.LastModified < uint64(newerThanUnix) {
+			glog.V(3).Infof("Skipping this file, as it's old enough: LastModified %d vs %d",
+				n.LastModified, newerThanUnix)
+			return nil
+		}
+		scanner.counter++
+		if *limit > 0 && scanner.counter > *limit {
+			return io.EOF
+		}
+		if tarOutputFile != nil {
+			return writeFile(vid, n)
+		} else {
+			printNeedle(vid, n, scanner.version, false)
+			return nil
+		}
+	}
+	if !ok {
+		if *showDeleted && tarOutputFile == nil {
+			if n.DataSize > 0 {
+				printNeedle(vid, n, scanner.version, true)
+			} else {
+				n.Name = []byte("*tombstone")
+				printNeedle(vid, n, scanner.version, true)
+			}
+		}
+		glog.V(2).Infof("This seems deleted %d size %d", n.Id, n.Size)
+	} else {
+		glog.V(2).Infof("Skipping later-updated Id %d size %d", n.Id, n.Size)
+	}
+	return nil
+}
+
 func runExport(cmd *Command, args []string) bool {
 
 	var err error
@@ -145,55 +201,16 @@ func runExport(cmd *Command, args []string) bool {
 		glog.Fatalf("cannot load needle map from %s: %s", indexFile.Name(), err)
 	}
 
-	var version storage.Version
+	volumeFileScanner := &VolumeFileScanner4Export{
+		needleMap: needleMap,
+		vid:       vid,
+	}
 
 	if tarOutputFile == nil {
 		fmt.Printf("key\tname\tsize\tgzip\tmime\tmodified\tttl\tdeleted\n")
 	}
 
-	var counter = 0
-
-	err = storage.ScanVolumeFile(*export.dir, *export.collection, vid,
-		storage.NeedleMapInMemory,
-		func(superBlock storage.SuperBlock) error {
-			version = superBlock.Version()
-			return nil
-		}, true, func(n *storage.Needle, offset int64) error {
-			nv, ok := needleMap.Get(n.Id)
-			glog.V(3).Infof("key %d offset %d size %d disk_size %d gzip %v ok %v nv %+v",
-				n.Id, offset, n.Size, n.DiskSize(version), n.IsGzipped(), ok, nv)
-			if ok && nv.Size > 0 && int64(nv.Offset)*types.NeedlePaddingSize == offset {
-				if newerThanUnix >= 0 && n.HasLastModifiedDate() && n.LastModified < uint64(newerThanUnix) {
-					glog.V(3).Infof("Skipping this file, as it's old enough: LastModified %d vs %d",
-						n.LastModified, newerThanUnix)
-					return nil
-				}
-				counter++
-				if *limit > 0 && counter > *limit {
-					return io.EOF
-				}
-				if tarOutputFile != nil {
-					return writeFile(vid, n)
-				} else {
-					printNeedle(vid, n, version, false)
-					return nil
-				}
-			}
-			if !ok {
-				if *showDeleted && tarOutputFile == nil {
-					if n.DataSize > 0 {
-						printNeedle(vid, n, version, true)
-					} else {
-						n.Name = []byte("*tombstone")
-						printNeedle(vid, n, version, true)
-					}
-				}
-				glog.V(2).Infof("This seems deleted %d size %d", n.Id, n.Size)
-			} else {
-				glog.V(2).Infof("Skipping later-updated Id %d size %d", n.Id, n.Size)
-			}
-			return nil
-		})
+	err = storage.ScanVolumeFile(*export.dir, *export.collection, vid, storage.NeedleMapInMemory, volumeFileScanner)
 	if err != nil && err != io.EOF {
 		glog.Fatalf("Export Volume File [ERROR] %s\n", err)
 	}

--- a/weed/storage/needle_read_write_test.go
+++ b/weed/storage/needle_read_write_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"crypto/rand"
+	"github.com/chrislusf/seaweedfs/weed/storage/types"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestAppend(t *testing.T) {
+	n := &Needle{
+
+		Cookie:       types.Cookie(123),   // Cookie Cookie   `comment:"random number to mitigate brute force lookups"`
+		Id:           types.NeedleId(123), // Id     NeedleId `comment:"needle id"`
+		Size:         8,                   // Size   uint32   `comment:"sum of DataSize,Data,NameSize,Name,MimeSize,Mime"`
+		DataSize:     4,                   // DataSize     uint32 `comment:"Data size"` //version2
+		Data:         []byte("abcd"),      // Data         []byte `comment:"The actual file data"`
+		Flags:        0,                   // Flags        byte   `comment:"boolean flags"`          //version2
+		NameSize:     0,                   // NameSize     uint8                                     //version2
+		Name:         nil,                 // Name         []byte `comment:"maximum 256 characters"` //version2
+		MimeSize:     0,                   // MimeSize     uint8                                     //version2
+		Mime:         nil,                 // Mime         []byte `comment:"maximum 256 characters"` //version2
+		PairsSize:    0,                   // PairsSize    uint16                                    //version2
+		Pairs:        nil,                 // Pairs        []byte `comment:"additional name value pairs, json format, maximum 6
+		LastModified: 123,                 // LastModified uint64 //only store LastModifiedBytesLength bytes, which is 5 bytes
+		Ttl:          nil,                 // Ttl          *TTL
+		Checksum:     123,                 // Checksum   CRC    `comment:"CRC32 to check integrity"`
+		AppendAtNs:   123,                 // AppendAtNs uint64 `comment:"append timestamp in nano seconds"` //version3
+		Padding:      nil,                 // Padding    []byte `comment:"Aligned to 8 bytes"`
+	}
+
+	tempFile, err := ioutil.TempFile("", ".dat")
+	if err != nil {
+		t.Errorf("Fail TempFile. %v", err)
+		return
+	}
+
+	/*
+		uint8  : 0 to 255
+		uint16 : 0 to 65535
+		uint32 : 0 to 4294967295
+		uint64 : 0 to 18446744073709551615
+		int8   : -128 to 127
+		int16  : -32768 to 32767
+		int32  : -2147483648 to 2147483647
+		int64  : -9223372036854775808 to 9223372036854775807
+	*/
+
+	fileSize := int64(4294967295) + 10000
+	io.CopyN(tempFile, rand.Reader, fileSize)
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	}()
+
+	offset, _, _, _ := n.Append(tempFile, CurrentVersion)
+	if offset != uint64(fileSize) {
+		t.Errorf("Fail to Append Needle.")
+	}
+}

--- a/weed/storage/volume_read_write.go
+++ b/weed/storage/volume_read_write.go
@@ -76,7 +76,7 @@ func (v *Volume) AppendBlob(b []byte) (offset int64, err error) {
 	return
 }
 
-func (v *Volume) writeNeedle(n *Needle) (offset Offset, size uint32, err error) {
+func (v *Volume) writeNeedle(n *Needle) (offset uint64, size uint32, err error) {
 	glog.V(4).Infof("writing needle %s", NewFileIdFromNeedle(v.Id, n).String())
 	if v.readOnly {
 		err = fmt.Errorf("%s is read-only", v.dataFile.Name())
@@ -96,8 +96,8 @@ func (v *Volume) writeNeedle(n *Needle) (offset Offset, size uint32, err error) 
 	}
 
 	nv, ok := v.nm.Get(n.Id)
-	if !ok || Offset(nv.Offset)*NeedlePaddingSize < offset {
-		if err = v.nm.Put(n.Id, offset/NeedlePaddingSize, n.Size); err != nil {
+	if !ok || uint64(nv.Offset)*NeedlePaddingSize < offset {
+		if err = v.nm.Put(n.Id, Offset(offset/NeedlePaddingSize), n.Size); err != nil {
 			glog.V(4).Infof("failed to save in needle map %d: %v", n.Id, err)
 		}
 	}
@@ -124,7 +124,7 @@ func (v *Volume) deleteNeedle(n *Needle) (uint32, error) {
 		if err != nil {
 			return size, err
 		}
-		if err = v.nm.Delete(n.Id, offset/NeedlePaddingSize); err != nil {
+		if err = v.nm.Delete(n.Id, Offset(offset/NeedlePaddingSize)); err != nil {
 			return size, err
 		}
 		return size, err


### PR DESCRIPTION
when volume file size exceeds 4294967295 (max of uint32), the volume offset will overflow. so just to change the offset to uint64.