### PR TITLE
Add replication-job Mode For The Docker Container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,20 @@
 FROM frolvlad/alpine-glibc
 
+# Supercronic install settings
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.8/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=be43e64c45acd6ec4fce5831e03759c89676a0ea
+
+# Install SeaweedFS and Supercronic ( for cron job mode )
 # Tried to use curl only (curl -o /tmp/linux_amd64.tar.gz ...), however it turned out that the following tar command failed with "gzip: stdin: not in gzip format"
 RUN apk add --no-cache --virtual build-dependencies --update wget curl ca-certificates && \
     wget -P /tmp https://github.com/$(curl -s -L https://github.com/chrislusf/seaweedfs/releases/latest | egrep -o 'chrislusf/seaweedfs/releases/download/.*/linux_amd64.tar.gz') && \
     tar -C /usr/bin/ -xzvf /tmp/linux_amd64.tar.gz && \
+    curl -fsSLO "$SUPERCRONIC_URL" && \
+    echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - && \
+    chmod +x "$SUPERCRONIC" && \
+    mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" && \
+    ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic && \
     apk del build-dependencies && \
     rm -rf /tmp/*
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -44,6 +44,14 @@ case "$1" in
   	exec /usr/bin/weed $@ $ARGS
 	;;
 
+  'cronjob')
+	MASTER=${WEED_MASTER-localhost:9333}
+	CRON_SCHEDULE=${CRON_SCHEDULE-*/5 * * * * *}
+	echo "$CRON_SCHEDULE" 'echo "volume.fix.replication" | weed shell -master='$MASTER > /crontab
+	echo "Running Crontab:"
+	cat /crontab
+	exec supercronic /crontab
+	;;
   *)
   	exec /usr/bin/weed $@
 	;;

--- a/docker/seaweedfs-compose.yml
+++ b/docker/seaweedfs-compose.yml
@@ -26,6 +26,16 @@ services:
     depends_on:
     - master
     - volume
+  cronjob:
+    image: chrislusf/seaweedfs # use a remote image
+    command: 'cronjob'
+    environment:
+      # Run re-replication every 2 minutes
+      CRON_SCHEDULE: '*/2 * * * * *' # Default: '*/5 * * * * *'
+      WEED_MASTER: master:9333 # Default: localhost:9333
+    depends_on:
+    - master
+    - volume
   s3:
     image: chrislusf/seaweedfs # use a remote image
     ports:


### PR DESCRIPTION
The container job is working, but for some reason I get an error when trying to use `weed shell` with the Docker Compose setup ( and therefore the replication-job mode with Compose ):

```
error: rpc error: code = Unimplemented desc = unknown service master_pb.Seaweed
```

I did successfully test the replication job with a local cluster on Docker swarm so I know that the job is running correctly.