### PR TITLE
fix wdclient bug

### DIFF
--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -60,6 +60,7 @@ func (mc *MasterClient) tryAllMasters() {
 		}
 
 		mc.currentMaster = ""
+		mc.vidMap = newVidMap()
 	}
 }
 


### PR DESCRIPTION
Here is a situation may cause bug:

Seaweedfs topo:
host1: master1(leader), volume1
host2: master2, volume2
host3: master3, volume3

When host1 down, master1 and volume1 crash simultaneously, the leader election take some time, volume1 hasn't send heartbeat to new leader, so the new leader cannot detect that volume1 crashed,  and won't send `DeletedVids` to the wdclient. **Now, wdclient caches the crashed volume1 location.**

---

这里有个场景会导致wdclient出现bug：
seaweedfs部署拓扑：
host1: master1(leader), volume1
host2: master2, volume2
host3: master3, volume3

如果host1挂了，master1和volume1同时下线，新leader选举需要一段时间，volume1没有给新leader发送过心跳，所以leader没有检测到volume1下线，因此没有给wdclient发送DeletedVids消息。**此时，wdclient将缓存着已经下线的volume1地址。**