### PR TITLE
volume: read dat files' last modified time correctly

### DIFF
--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -31,12 +31,12 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		}
 		if canWrite {
 			v.dataFile, e = os.OpenFile(fileName+".dat", os.O_RDWR|os.O_CREATE, 0644)
-			v.lastModifiedTsSeconds = uint64(modifiedTime.Unix())
 		} else {
 			glog.V(0).Infoln("opening " + fileName + ".dat in READONLY mode")
 			v.dataFile, e = os.Open(fileName + ".dat")
 			v.readOnly = true
 		}
+		v.lastModifiedTsSeconds = uint64(modifiedTime.Unix())
 		if fileSize >= _SuperBlockSize {
 			alreadyHasSuperBlock = true
 		}


### PR DESCRIPTION
When .dat file is 666 readonly mode, seaweedfs currently do not read the file's last modified time, this cause the file to be expired, and will be deleted.