### PR TITLE
volume: add fsync threshold

### DIFF
--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/pb/volume_server_pb"
-	"github.com/chrislusf/seaweedfs/weed/server"
+	weed_server "github.com/chrislusf/seaweedfs/weed/server"
 	"github.com/chrislusf/seaweedfs/weed/storage"
 	"github.com/chrislusf/seaweedfs/weed/util"
 	"google.golang.org/grpc/reflection"
@@ -44,6 +44,7 @@ type VolumeServerOptions struct {
 	cpuProfile            *string
 	memProfile            *string
 	compactionMBPerSecond *int
+	fsyncThreshold        *int
 }
 
 func init() {
@@ -64,6 +65,7 @@ func init() {
 	v.cpuProfile = cmdVolume.Flag.String("cpuprofile", "", "cpu profile output file")
 	v.memProfile = cmdVolume.Flag.String("memprofile", "", "memory profile output file")
 	v.compactionMBPerSecond = cmdVolume.Flag.Int("compactionMBps", 0, "limit background compaction or copying speed in mega bytes per second")
+	v.fsyncThreshold = cmdVolume.Flag.Int("fsyncThreshold", 0, "call fsync when have written fsyncThreshold objects, set to 0 will not call fsync")
 }
 
 var cmdVolume = &Command{
@@ -156,6 +158,7 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 		v.whiteList,
 		*v.fixJpgOrientation, *v.readRedirect,
 		*v.compactionMBPerSecond,
+		*v.fsyncThreshold,
 	)
 
 	listeningAddress := *v.bindIp + ":" + strconv.Itoa(*v.port)

--- a/weed/server/volume_server.go
+++ b/weed/server/volume_server.go
@@ -29,6 +29,7 @@ type VolumeServer struct {
 	compactionBytePerSecond int64
 	MetricsAddress          string
 	MetricsIntervalSec      int
+	fsyncThreshold          int
 }
 
 func NewVolumeServer(adminMux, publicMux *http.ServeMux, ip string,
@@ -41,6 +42,7 @@ func NewVolumeServer(adminMux, publicMux *http.ServeMux, ip string,
 	fixJpgOrientation bool,
 	readRedirect bool,
 	compactionMBPerSecond int,
+	fsyncThreshold int,
 ) *VolumeServer {
 
 	v := viper.GetViper()
@@ -62,9 +64,10 @@ func NewVolumeServer(adminMux, publicMux *http.ServeMux, ip string,
 		ReadRedirect:            readRedirect,
 		grpcDialOption:          security.LoadClientTLS(viper.Sub("grpc"), "volume"),
 		compactionBytePerSecond: int64(compactionMBPerSecond) * 1024 * 1024,
+		fsyncThreshold:          fsyncThreshold,
 	}
 	vs.SeedMasterNodes = masterNodes
-	vs.store = storage.NewStore(vs.grpcDialOption, port, ip, publicUrl, folders, maxCounts, vs.needleMapKind)
+	vs.store = storage.NewStore(vs.grpcDialOption, port, ip, publicUrl, folders, maxCounts, vs.needleMapKind, vs.fsyncThreshold)
 
 	vs.guard = security.NewGuard(whiteList, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec)
 


### PR DESCRIPTION
Volume server count how many object has been written, 
if the number of objects is bigger than threshold, sync the kernel cache.

===
给volume server加了启动参数fsyncThreshold，volume每写fsyncThreshold个对象，执行一次fsync。