### PR TITLE
s3 api: fix listbucket common_prefixes issue

### DIFF
--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -91,6 +91,11 @@ func (s3a *S3ApiServer) completeMultipartUpload(ctx context.Context, input *s3.C
 	}
 	dirName = fmt.Sprintf("%s/%s/%s", s3a.option.BucketsPath, *input.Bucket, dirName)
 
+	// remove suffix '/'
+	if strings.HasSuffix(dirName, "/") {
+		dirName = dirName[:len(dirName)-1]
+	}
+
 	err = s3a.mkFile(ctx, dirName, entryName, finalParts)
 
 	if err != nil {

--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -125,9 +125,11 @@ func (s3a *S3ApiServer) listFilerEntries(ctx context.Context, bucket, originalPr
 			}
 			lastEntryName = entry.Name
 			if entry.IsDirectory {
-				commonPrefixes = append(commonPrefixes, PrefixEntry{
-					Prefix: fmt.Sprintf("%s%s/", dir, entry.Name),
-				})
+				if entry.Name != ".uploads" {
+					commonPrefixes = append(commonPrefixes, PrefixEntry{
+						Prefix: fmt.Sprintf("%s%s/", dir, entry.Name),
+					})
+				}
 			} else {
 				contents = append(contents, ListEntry{
 					Key:          fmt.Sprintf("%s%s", dir, entry.Name),

--- a/weed/s3api/s3api_xsd_generated.go
+++ b/weed/s3api/s3api_xsd_generated.go
@@ -675,7 +675,7 @@ type PostResponse struct {
 }
 
 type PrefixEntry struct {
-	Prefix string `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Prefix"`
+	Prefix string `xml:"Prefix"`
 }
 
 type PutObject struct {


### PR DESCRIPTION
1, correct debug log when dirName is empty

```
I0929 20:05:49 26629 filer_util.go:68] create file: /buckets/test//60M.data
```

2, disable .uploads output to common prefixs 

```
common_prefixes =  {'list': [{u'LastModified': u'2019-09-29T20:00:58+08:00', u'ETag': u'"e599adac"', u'StorageClass': u'STANDARD', u'Key': u'60M.data', u'Owner': [{u'ID': u'0'}], u'Size': u'62914560'}], 'common_prefixes': [{u'{http://s3.amazonaws.com/doc/2006-03-01/}Prefix': u'.uploads/'}], 'truncated': False}
```