### PR TITLE
fix benchmark cmd usage info

### DIFF
--- a/weed/command/benchmark.go
+++ b/weed/command/benchmark.go
@@ -69,7 +69,7 @@ func init() {
 }
 
 var cmdBenchmark = &Command{
-	UsageLine: "benchmark -server=localhost:9333 -c=10 -n=100000",
+	UsageLine: "benchmark -master=localhost:9333 -c=10 -n=100000",
 	Short:     "benchmark on writing millions of files and read out",
 	Long: `benchmark on an empty SeaweedFS file system.
 


### PR DESCRIPTION
Weed benchmark command use "-master" option to set master server, but usage example give a misleading "-server" option.