### PR TITLE
fix abused 404 status code

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -32,10 +32,15 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request, 
 			fs.listDirectoryHandler(w, r)
 			return
 		}
-		glog.V(1).Infof("Not found %s: %v", path, err)
-
-		stats.FilerRequestCounter.WithLabelValues("read.notfound").Inc()
-		w.WriteHeader(http.StatusNotFound)
+		if err == filer2.ErrNotFound {
+			glog.V(1).Infof("Not found %s: %v", path, err)
+			stats.FilerRequestCounter.WithLabelValues("read.notfound").Inc()
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			glog.V(0).Infof("Internal %s: %v", path, err)
+			stats.FilerRequestCounter.WithLabelValues("read.internalerror").Inc()
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 		return
 	}
 


### PR DESCRIPTION
Hi,
I found that the `filer`'s storage will always return a `not found` error, which is sometimes wrong. 