### PR TITLE
can not break out of from for-select block

### DIFF
--- a/weed/topology/topology_vacuum.go
+++ b/weed/topology/topology_vacuum.go
@@ -35,13 +35,12 @@ func batchVacuumVolumeCheck(grpcDialOption grpc.DialOption, vl *VolumeLayout, vi
 		}(index, dn.Url(), vid)
 	}
 	isCheckSuccess := true
-	for _ = range locationlist.list {
+	for range locationlist.list {
 		select {
 		case canVacuum := <-ch:
 			isCheckSuccess = isCheckSuccess && canVacuum
 		case <-time.After(30 * time.Minute):
-			isCheckSuccess = false
-			break
+			return false
 		}
 	}
 	return isCheckSuccess
@@ -71,13 +70,12 @@ func batchVacuumVolumeCompact(grpcDialOption grpc.DialOption, vl *VolumeLayout, 
 		}(index, dn.Url(), vid)
 	}
 	isVacuumSuccess := true
-	for _ = range locationlist.list {
+	for range locationlist.list {
 		select {
 		case canCommit := <-ch:
 			isVacuumSuccess = isVacuumSuccess && canCommit
 		case <-time.After(30 * time.Minute):
-			isVacuumSuccess = false
-			break
+			return false
 		}
 	}
 	return isVacuumSuccess


### PR DESCRIPTION
Hi, 
I think you want to stop the gc processing if it is time out.  But `break` can not out of `for-select` block.

Here is the [spec](https://golang.org/ref/spec#Break_statements)

And here is a simple poc:

``` go
package main

import (
	"fmt"
	"runtime"
	"time"
)

func main() {
	c := make(chan int)
	go func() {
		for {
			c <- 1
		}
	}()
	for {
		select {
		case <-time.After(time.Second * 3):
			fmt.Printf("after 3s")
		case <-c:
			break
		}
	}
	fmt.Println("over")
}
```
Output is nothing