### PR TITLE
Fix missing leading dot in extension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
 	github.com/facebookgo/stats v0.0.0-20151006221625-1b76add642e4
 	github.com/frankban/quicktest v1.7.2 // indirect
-	github.com/gabriel-vasile/mimetype v0.3.17
+	github.com/gabriel-vasile/mimetype v1.0.0
 	github.com/go-redis/redis v6.15.2+incompatible
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gocql/gocql v0.0.0-20190829130954-e163eff7a8c6

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gabriel-vasile/mimetype v0.3.17 h1:NGWgggJJqTofUcTV1E7hkk2zVjZ54EfJa1z5O3z6By4=
 github.com/gabriel-vasile/mimetype v0.3.17/go.mod h1:kMJbg3SlWZCsj4R73F1WDzbT9AyGCOVmUtIxxwO5pmI=
+github.com/gabriel-vasile/mimetype v1.0.0 h1:0QKnAQQhG6oOsb4GK7iPlet7RtjHi9us8RF/nXoTxhI=
+github.com/gabriel-vasile/mimetype v1.0.0/go.mod h1:6CDPel/o/3/s4+bp6kIbsWATq8pmgOisOPG40CJa6To=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=

--- a/weed/filesys/filehandle.go
+++ b/weed/filesys/filehandle.go
@@ -92,9 +92,9 @@ func (fh *FileHandle) Write(ctx context.Context, req *fuse.WriteRequest, resp *f
 
 	if req.Offset == 0 {
 		// detect mime type
-		var possibleExt string
-		fh.contentType, possibleExt = mimetype.Detect(req.Data)
-		if ext := path.Ext(fh.f.Name); ext != possibleExt {
+		detectedMIME := mimetype.Detect(req.Data)
+		fh.contentType = detectedMIME.String()
+		if ext := path.Ext(fh.f.Name); ext != detectedMIME.Extension() {
 			fh.contentType = mime.TypeByExtension(ext)
 		}
 


### PR DESCRIPTION
This fixes a mismatch between [path.Ext](https://godoc.org/path#Ext) function and the mimetype library.
path.Ext returns the extension with a leading dot, but mimetype previously (v0.3.17) did not have the leading dot. Now, in v1.0.0, mimetype has the leading dot https://godoc.org/github.com/gabriel-vasile/mimetype#MIME.Extension