### PR TITLE
Add readOnly and routeByLatency options to Redis Cluster Store

### DIFF
--- a/weed/command/scaffold.go
+++ b/weed/command/scaffold.go
@@ -136,6 +136,8 @@ addresses = [
     "localhost:30006",
 ]
 password = ""
+readOnly = true
+routeByLatency = true
 
 [etcd]
 enabled = false

--- a/weed/filer2/redis/redis_cluster_store.go
+++ b/weed/filer2/redis/redis_cluster_store.go
@@ -22,13 +22,17 @@ func (store *RedisClusterStore) Initialize(configuration util.Configuration) (er
 	return store.initialize(
 		configuration.GetStringSlice("addresses"),
 		configuration.GetString("password"),
+		configuration.GetBool("connection_use_read_only"),
+		configuration.GetBool("connection_route_by_latency"),
 	)
 }
 
-func (store *RedisClusterStore) initialize(addresses []string, password string) (err error) {
+func (store *RedisClusterStore) initialize(addresses []string, password string, readOnly, routeByLatency bool) (err error) {
 	store.Client = redis.NewClusterClient(&redis.ClusterOptions{
-		Addrs:    addresses,
-		Password: password,
+		Addrs:          addresses,
+		Password:       password,
+		ReadOnly:       readOnly,
+		RouteByLatency: routeByLatency,
 	})
 	return
 }

--- a/weed/filer2/redis/redis_cluster_store.go
+++ b/weed/filer2/redis/redis_cluster_store.go
@@ -22,8 +22,8 @@ func (store *RedisClusterStore) Initialize(configuration util.Configuration) (er
 	return store.initialize(
 		configuration.GetStringSlice("addresses"),
 		configuration.GetString("password"),
-		configuration.GetBool("connection_use_read_only"),
-		configuration.GetBool("connection_route_by_latency"),
+		configuration.GetBool("useReadOnly"),
+		configuration.GetBool("routeByLatency"),
 	)
 }
 


### PR DESCRIPTION
I am running SeaweedFS in a multi-zone AWS environment where latency between the Filer and the Redis cluster is very important. However, by default the Go Redis client communicates with only the master node, which may be in a different AWS zone. This change will add configuration options to allow the Filer's Redis client to read from the closest Redis node, while still writing to the master Redis.