### PR TITLE
decouple the volume.Destroy() from the operation of unmountVolume()

### DIFF
--- a/weed/storage/disk_location_ec.go
+++ b/weed/storage/disk_location_ec.go
@@ -169,3 +169,17 @@ func (l *DiskLocation) deleteEcVolumeById(vid needle.VolumeId) (e error) {
 	delete(l.ecVolumes, vid)
 	return
 }
+
+func (l *DiskLocation) unmountEcVolumeByCollection(collectionName string) map[needle.VolumeId]*erasure_coding.EcVolume {
+	deltaVols := make(map[needle.VolumeId]*erasure_coding.EcVolume, 0)
+	for k, v := range l.ecVolumes {
+		if v.Collection == collectionName {
+			deltaVols[k] = v
+		}
+	}
+
+	for k, _ := range deltaVols {
+		delete(l.ecVolumes, k)
+	}
+	return deltaVols
+}


### PR DESCRIPTION
delete many volumes by collection name, the volume server will not be writen for a long time.
I decouple the volume.Destroy() from the the [ec]VolumesLock, to improve the concurrency.