### PR TITLE
feat: drains http body if buffer is too small

### DIFF
--- a/weed/util/http_util.go
+++ b/weed/util/http_util.go
@@ -235,8 +235,16 @@ func ReadUrl(fileUrl string, offset int64, size int, buf []byte, isReadRange boo
 		if err != nil {
 			return n, err
 		}
+		if n == int64(len(buf)) {
+			break
+		}
 	}
-
+	// drains the response body to avoid memory leak
+	data, err := ioutil.ReadAll(reader)
+	if len(data) != 0 {
+		err = fmt.Errorf("buffer size is too small. remains %d", len(data))
+	}
+	return n, err
 }
 
 func ReadUrlAsStream(fileUrl string, offset int64, size int, fn func(data []byte)) (int64, error) {


### PR DESCRIPTION
Hi Chris,

I found that if the given `buf` size is smaller than the "response.body" size, there is an error. I think it should be reported as an error. And `response.body` should be drained to avoid `memory leaks`.

Thanks.