### PR TITLE
Support wav files compression

### DIFF
--- a/weed/util/compression.go
+++ b/weed/util/compression.go
@@ -60,7 +60,7 @@ func UnGzipData(input []byte) ([]byte, error) {
 
 	// images
 	switch ext {
-	case ".svg", ".bmp":
+	case ".svg", ".bmp", ".wav":
 		return true, true
 	}
 	if strings.HasPrefix(mtype, "image/") {
@@ -85,6 +85,14 @@ func UnGzipData(input []byte) ([]byte, error) {
 			return true, true
 		}
 		if strings.HasSuffix(mtype, "script") {
+			return true, true
+		}
+
+	}
+
+	if strings.HasPrefix(mtype, "audio/") {
+		switch strings.TrimPrefix(mtype, "audio/") {
+		case "wave", "wav", "x-wav", "x-pn-wav":
 			return true, true
 		}
 	}


### PR DESCRIPTION
Audio/wav files are yet very common in some domains and are 
good candidates for compression, up to 3 times with lowest compression
level.