### PR TITLE
Update stats and status volume server

### DIFF
--- a/weed/pb/volume_server_pb/volume_server.pb.go
+++ b/weed/pb/volume_server_pb/volume_server.pb.go
@@ -1505,10 +1505,12 @@ func (m *ReadVolumeFileStatusResponse) GetCollection() string {
 }
 
 type DiskStatus struct {
-	Dir  string `protobuf:"bytes,1,opt,name=dir" json:"dir,omitempty"`
-	All  uint64 `protobuf:"varint,2,opt,name=all" json:"all,omitempty"`
-	Used uint64 `protobuf:"varint,3,opt,name=used" json:"used,omitempty"`
-	Free uint64 `protobuf:"varint,4,opt,name=free" json:"free,omitempty"`
+	Dir         string  `protobuf:"bytes,1,opt,name=dir" json:"dir,omitempty"`
+	All         uint64  `protobuf:"varint,2,opt,name=all" json:"all,omitempty"`
+	Used        uint64  `protobuf:"varint,3,opt,name=used" json:"used,omitempty"`
+	Free        uint64  `protobuf:"varint,4,opt,name=free" json:"free,omitempty"`
+	PercentFree float32 `protobuf:"fixed32,5,opt,name=percentFree" json:"percentFree,omitempty"`
+	PercentUsed float32 `protobuf:"fixed32,6,opt,name=percentUsed" json:"percentUsed,omitempty"`
 }
 
 func (m *DiskStatus) Reset()                    { *m = DiskStatus{} }
@@ -1542,6 +1544,20 @@ func (m *DiskStatus) GetFree() uint64 {
 		return m.Free
 	}
 	return 0
+}
+
+func (m *DiskStatus) GetPercentFree() float32 {
+	if m != nil {
+		return m.PercentFree
+	}
+	return float32(0.0)
+}
+
+func (m *DiskStatus) GetPercentUsed() float32 {
+	if m != nil {
+		return m.PercentUsed
+	}
+	return float32(0.0)
 }
 
 type MemStatus struct {

--- a/weed/server/volume_server_handlers_admin.go
+++ b/weed/server/volume_server_handlers_admin.go
@@ -12,6 +12,13 @@ import (
 func (vs *VolumeServer) statusHandler(w http.ResponseWriter, r *http.Request) {
 	m := make(map[string]interface{})
 	m["Version"] = util.VERSION
+	var ds []*volume_server_pb.DiskStatus
+	for _, loc := range vs.store.Locations {
+		if dir, e := filepath.Abs(loc.Directory); e == nil {
+			ds = append(ds, stats.NewDiskStatus(dir))
+		}
+	}
+	m["DiskStatuses"] = ds
 	m["Volumes"] = vs.store.VolumeInfos()
 	writeJsonQuiet(w, r, http.StatusOK, m)
 }

--- a/weed/stats/disk_supported.go
+++ b/weed/stats/disk_supported.go
@@ -17,5 +17,7 @@ func fillInDiskStatus(disk *volume_server_pb.DiskStatus) {
 	disk.All = fs.Blocks * uint64(fs.Bsize)
 	disk.Free = fs.Bfree * uint64(fs.Bsize)
 	disk.Used = disk.All - disk.Free
+	disk.PercentFree = float32((float64(disk.Free) / float64(disk.All)) * 100)
+	disk.PercentUsed = float32((float64(disk.Used) / float64(disk.All)) * 100)
 	return
 }


### PR DESCRIPTION
Adding PercentFree & PercentUsage to the DiskStatus (stats)
Exposing DiskStatus in the /status route for volume server:
 best to have volume stat and disk(os) stats in a single route

output:
![image](https://user-images.githubusercontent.com/45972051/75120425-939e6000-5694-11ea-9db3-a10c64225cc8.png)
