### PR TITLE
add fsync option for benchmark

### DIFF
--- a/weed/command/benchmark.go
+++ b/weed/command/benchmark.go
@@ -42,6 +42,7 @@ type BenchmarkOptions struct {
 	grpcDialOption   grpc.DialOption
 	masterClient     *wdclient.MasterClient
 	grpcRead         *bool
+	fsync            *bool
 }
 
 var (
@@ -67,6 +68,7 @@ func init() {
 	b.cpuprofile = cmdBenchmark.Flag.String("cpuprofile", "", "cpu profile output file")
 	b.maxCpu = cmdBenchmark.Flag.Int("maxCpu", 0, "maximum number of CPUs. 0 means all available CPUs")
 	b.grpcRead = cmdBenchmark.Flag.Bool("grpcRead", false, "use grpc API to read")
+	b.fsync = cmdBenchmark.Flag.Bool("fsync", false, "flush data to disk after write")
 	sharedBytes = make([]byte, 1024)
 }
 
@@ -230,6 +232,7 @@ func writeFiles(idChan chan int, fileIdLineChan chan string, s *stat) {
 			Reader:   &FakeReader{id: uint64(id), size: fileSize, random: random},
 			FileSize: fileSize,
 			MimeType: "image/bench", // prevent gzip benchmark content
+			Fsync: *b.fsync,
 		}
 		ar := &operation.VolumeAssignRequest{
 			Count:       1,

--- a/weed/operation/submit.go
+++ b/weed/operation/submit.go
@@ -27,6 +27,7 @@ type FilePart struct {
 	Ttl         string
 	Server      string //this comes from assign result
 	Fid         string //this comes from assign result, but customizable
+	Fsync       bool      
 }
 
 type SubmitResult struct {
@@ -115,6 +116,9 @@ func (fi FilePart) Upload(maxMB int, master string, usePublicUrl bool, jwt secur
 	fileUrl := "http://" + fi.Server + "/" + fi.Fid
 	if fi.ModTime != 0 {
 		fileUrl += "?ts=" + strconv.Itoa(int(fi.ModTime))
+	}
+	if fi.Fsync {
+		fileUrl += "?fsync=true"
 	}
 	if closer, ok := fi.Reader.(io.Closer); ok {
 		defer closer.Close()


### PR DESCRIPTION
Add fsync option for benchmark, provide convenience to compare performance between fsync and not.

./weed benchmark -master=localhost:9333 -c=64 -n=100000 -size=10000 -fsync=true

Concurrency Level:      64
Time taken for tests:   101.052 seconds
Complete requests:      100000
Failed requests:        0
Total transferred:      1003143900 bytes
Requests per second:    989.59 [#/sec]
Transfer rate:          9694.31 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        1.2      64.6       394.9      51.5

Percentage of the requests served within a certain time (ms)
   50%     51.9 ms
   66%     74.3 ms
   75%     91.4 ms
   80%    103.2 ms
   90%    136.2 ms
   95%    166.9 ms
   98%    207.2 ms
   99%    229.1 ms
  100%    394.9 ms