### PR TITLE
use async write to persistent file to disk - part1

### DIFF
--- a/weed/storage/needle/async_request.go
+++ b/weed/storage/needle/async_request.go
@@ -1,0 +1,55 @@
+package needle
+
+type AsyncRequest struct {
+	N              *Needle
+	IsWriteRequest bool
+	ActualSize     int64
+	Fsync          bool
+	offset         uint64
+	size           uint64
+	doneChan       chan interface{}
+	isUnchanged    bool
+	err            error
+}
+
+func NewAsyncRequest(n *Needle, isWriteRequest bool, fsync bool) *AsyncRequest {
+	return &AsyncRequest{
+		offset:         0,
+		size:           0,
+		ActualSize:     0,
+		doneChan:       make(chan interface{}),
+		N:              n,
+		isUnchanged:    false,
+		IsWriteRequest: isWriteRequest,
+		Fsync:          fsync,
+		err:            nil,
+	}
+}
+
+func (r *AsyncRequest) WaitComplete() (uint64, uint64, bool, error) {
+	<-r.doneChan
+	return r.offset, r.size, r.isUnchanged, r.err
+}
+
+func (r *AsyncRequest) Complete(offset uint64, size uint64, isUnchanged bool, err error) {
+	r.offset = offset
+	r.size = size
+	r.isUnchanged = isUnchanged
+	r.err = err
+	close(r.doneChan)
+}
+
+func (r *AsyncRequest) UpdateResult(offset uint64, size uint64, isUnchanged bool, err error) {
+	r.offset = offset
+	r.size = size
+	r.isUnchanged = isUnchanged
+	r.err = err
+}
+
+func (r *AsyncRequest) Submit() {
+	close(r.doneChan)
+}
+
+func (r *AsyncRequest) IsSucceed() bool {
+	return r.err == nil
+}

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -264,12 +264,7 @@ func (s *Store) WriteVolumeNeedle(i needle.VolumeId, n *needle.Needle, fsync boo
 			err = fmt.Errorf("volume %d is read only", i)
 			return
 		}
-		// using len(n.Data) here instead of n.Size before n.Size is populated in v.writeNeedle(n)
-		if MaxPossibleVolumeSize >= v.ContentSize()+uint64(needle.GetActualSize(uint32(len(n.Data)), v.Version())) {
-			_, _, isUnchanged, err = v.writeNeedle(n, fsync)
-		} else {
-			err = fmt.Errorf("volume size limit %d exceeded! current size is %d", s.GetVolumeSizeLimit(), v.ContentSize())
-		}
+		_, _, isUnchanged, err = v.writeNeedle2(n, fsync)
 		return
 	}
 	glog.V(0).Infoln("volume", i, "not found!")
@@ -282,11 +277,7 @@ func (s *Store) DeleteVolumeNeedle(i needle.VolumeId, n *needle.Needle) (uint32,
 		if v.noWriteOrDelete {
 			return 0, fmt.Errorf("volume %d is read only", i)
 		}
-		if MaxPossibleVolumeSize >= v.ContentSize()+uint64(needle.GetActualSize(0, v.Version())) {
-			return v.deleteNeedle(n)
-		} else {
-			return 0, fmt.Errorf("volume size limit %d exceeded! current size is %d", s.GetVolumeSizeLimit(), v.ContentSize())
-		}
+		return v.deleteNeedle2(n)
 	}
 	return 0, fmt.Errorf("volume %d not found on %s:%d", i, s.Ip, s.Port)
 }

--- a/weed/storage/volume.go
+++ b/weed/storage/volume.go
@@ -33,6 +33,7 @@ type Volume struct {
 	super_block.SuperBlock
 
 	dataFileAccessLock    sync.RWMutex
+	asyncRequestsChan     chan *needle.AsyncRequest
 	lastModifiedTsSeconds uint64 //unix time in seconds
 	lastAppendAtNs        uint64 //unix time in nanoseconds
 
@@ -46,12 +47,15 @@ type Volume struct {
 
 func NewVolume(dirname string, collection string, id needle.VolumeId, needleMapKind NeedleMapType, replicaPlacement *super_block.ReplicaPlacement, ttl *needle.TTL, preallocate int64, memoryMapMaxSizeMb uint32) (v *Volume, e error) {
 	// if replicaPlacement is nil, the superblock will be loaded from disk
-	v = &Volume{dir: dirname, Collection: collection, Id: id, MemoryMapMaxSizeMb: memoryMapMaxSizeMb}
+	v = &Volume{dir: dirname, Collection: collection, Id: id, MemoryMapMaxSizeMb: memoryMapMaxSizeMb,
+		asyncRequestsChan: make(chan *needle.AsyncRequest, 128)}
 	v.SuperBlock = super_block.SuperBlock{ReplicaPlacement: replicaPlacement, Ttl: ttl}
 	v.needleMapKind = needleMapKind
 	e = v.load(true, true, needleMapKind, preallocate)
+	v.startWorker()
 	return
 }
+
 func (v *Volume) String() string {
 	return fmt.Sprintf("Id:%v, dir:%s, Collection:%s, dataFile:%v, nm:%v, noWrite:%v canDelete:%v", v.Id, v.dir, v.Collection, v.DataBackend, v.nm, v.noWriteOrDelete || v.noWriteCanDelete, v.noWriteCanDelete)
 }
@@ -65,6 +69,7 @@ func VolumeFileName(dir string, collection string, id int) (fileName string) {
 	}
 	return
 }
+
 func (v *Volume) FileName() (fileName string) {
 	return VolumeFileName(v.dir, v.Collection, int(v.Id))
 }

--- a/weed/storage/volume_read_write.go
+++ b/weed/storage/volume_read_write.go
@@ -46,6 +46,7 @@ func (v *Volume) Destroy() (err error) {
 		err = fmt.Errorf("volume %d is compacting", v.Id)
 		return
 	}
+	close(v.asyncRequestsChan)
 	storageName, storageKey := v.RemoteStorageNameKey()
 	if v.HasRemoteFile() && storageName != "" && storageKey != "" {
 		if backendStorage, found := backend.BackendStorages[storageName]; found {
@@ -63,7 +64,11 @@ func (v *Volume) Destroy() (err error) {
 	return
 }
 
-func (v *Volume) writeNeedle(n *needle.Needle, fsync bool) (offset uint64, size uint32, isUnchanged bool, err error) {
+func (v *Volume) asyncRequestAppend(request *needle.AsyncRequest) {
+	v.asyncRequestsChan <- request
+}
+
+func (v *Volume) writeNeedleDeprecated(n *needle.Needle, fsync bool) (offset uint64, size uint32, isUnchanged bool, err error) {
 	// glog.V(4).Infof("writing needle %s", needle.NewFileIdFromNeedle(v.Id, n).String())
 	v.dataFileAccessLock.Lock()
 	defer v.dataFileAccessLock.Unlock()
@@ -117,10 +122,100 @@ func (v *Volume) writeNeedle(n *needle.Needle, fsync bool) (offset uint64, size 
 	return
 }
 
-func (v *Volume) deleteNeedle(n *needle.Needle) (uint32, error) {
+func (v *Volume) writeNeedle2(n *needle.Needle, fsync bool) (offset uint64, size uint32, isUnchanged bool, err error) {
+	// glog.V(4).Infof("writing needle %s", needle.NewFileIdFromNeedle(v.Id, n).String())
+	if n.Ttl == needle.EMPTY_TTL && v.Ttl != needle.EMPTY_TTL {
+		n.SetHasTtl()
+		n.Ttl = v.Ttl
+	}
+
+	asyncRequest := needle.NewAsyncRequest(n, true, fsync)
+	// using len(n.Data) here instead of n.Size before n.Size is populated in n.Append()
+	asyncRequest.ActualSize = needle.GetActualSize(uint32(len(n.Data)), v.Version())
+
+	v.asyncRequestAppend(asyncRequest)
+	offset, _, isUnchanged, err = asyncRequest.WaitComplete()
+
+	return
+}
+
+func (v *Volume) doWriteRequest(n *needle.Needle) (offset uint64, size uint32, isUnchanged bool, err error) {
+	// glog.V(4).Infof("writing needle %s", needle.NewFileIdFromNeedle(v.Id, n).String())
+	if v.isFileUnchanged(n) {
+		size = n.DataSize
+		isUnchanged = true
+		return
+	}
+
+	// check whether existing needle cookie matches
+	nv, ok := v.nm.Get(n.Id)
+	if ok {
+		existingNeedle, _, _, existingNeedleReadErr := needle.ReadNeedleHeader(v.DataBackend, v.Version(), nv.Offset.ToAcutalOffset())
+		if existingNeedleReadErr != nil {
+			err = fmt.Errorf("reading existing needle: %v", existingNeedleReadErr)
+			return
+		}
+		if existingNeedle.Cookie != n.Cookie {
+			glog.V(0).Infof("write cookie mismatch: existing %x, new %x", existingNeedle.Cookie, n.Cookie)
+			err = fmt.Errorf("mismatching cookie %x", n.Cookie)
+			return
+		}
+	}
+
+	// append to dat file
+	n.AppendAtNs = uint64(time.Now().UnixNano())
+	if offset, size, _, err = n.Append(v.DataBackend, v.Version()); err != nil {
+		return
+	}
+	v.lastAppendAtNs = n.AppendAtNs
+
+	// add to needle map
+	if !ok || uint64(nv.Offset.ToAcutalOffset()) < offset {
+		if err = v.nm.Put(n.Id, ToOffset(int64(offset)), n.Size); err != nil {
+			glog.V(4).Infof("failed to save in needle map %d: %v", n.Id, err)
+		}
+	}
+	if v.lastModifiedTsSeconds < n.LastModified {
+		v.lastModifiedTsSeconds = n.LastModified
+	}
+	return
+}
+
+func (v *Volume) deleteNeedleDeprecated(n *needle.Needle) (uint32, error) {
 	glog.V(4).Infof("delete needle %s", needle.NewFileIdFromNeedle(v.Id, n).String())
 	v.dataFileAccessLock.Lock()
 	defer v.dataFileAccessLock.Unlock()
+	nv, ok := v.nm.Get(n.Id)
+	//fmt.Println("key", n.Id, "volume offset", nv.Offset, "data_size", n.Size, "cached size", nv.Size)
+	if ok && nv.Size != TombstoneFileSize {
+		size := nv.Size
+		n.Data = nil
+		n.AppendAtNs = uint64(time.Now().UnixNano())
+		offset, _, _, err := n.Append(v.DataBackend, v.Version())
+		if err != nil {
+			return size, err
+		}
+		v.lastAppendAtNs = n.AppendAtNs
+		if err = v.nm.Delete(n.Id, ToOffset(int64(offset))); err != nil {
+			return size, err
+		}
+		return size, err
+	}
+	return 0, nil
+}
+
+func (v *Volume) deleteNeedle2(n *needle.Needle) (uint32, error) {
+	asyncRequest := needle.NewAsyncRequest(n, false, false)
+	asyncRequest.ActualSize = needle.GetActualSize(0, v.Version())
+
+	v.asyncRequestAppend(asyncRequest)
+	_, size, _, err := asyncRequest.WaitComplete()
+
+	return uint32(size), err
+}
+
+func (v *Volume) doDeleteRequest(n *needle.Needle) (uint32, error) {
+	glog.V(4).Infof("delete needle %s", needle.NewFileIdFromNeedle(v.Id, n).String())
 	nv, ok := v.nm.Get(n.Id)
 	//fmt.Println("key", n.Id, "volume offset", nv.Offset, "data_size", n.Size, "cached size", nv.Size)
 	if ok && nv.Size != TombstoneFileSize {
@@ -174,6 +269,87 @@ func (v *Volume) readNeedle(n *needle.Needle) (int, error) {
 		return bytesRead, nil
 	}
 	return -1, ErrorNotFound
+}
+
+func (v *Volume) startWorker() {
+	go func() {
+		chanClosed := false
+		for {
+			// chan closed. go thread will exit
+			if chanClosed {
+				break
+			}
+			fsync := false
+			currentRequests := make([]*needle.AsyncRequest, 0, 128)
+			currentBytesToWrite := int64(0)
+			for {
+				request, ok := <-v.asyncRequestsChan
+				//volume may be closed
+				if !ok {
+					chanClosed = true
+					break
+				}
+				if MaxPossibleVolumeSize < v.ContentSize()+uint64(currentBytesToWrite+request.ActualSize) {
+					request.Complete(0, 0, false,
+						fmt.Errorf("volume size limit %d exceeded! current size is %d", MaxPossibleVolumeSize, v.ContentSize()))
+					break
+				}
+				currentRequests = append(currentRequests, request)
+				currentBytesToWrite += request.ActualSize
+				if request.Fsync {
+					fsync = true
+				}
+				// submit at most 4M bytes or 128 requests at one time to decrease request delay.
+				// it also need to break if there is no data in channel to avoid io hang.
+				if currentBytesToWrite >= 4*1024*1024 || len(currentRequests) >= 128 || len(v.asyncRequestsChan) == 0 {
+					break
+				}
+			}
+			if len(currentRequests) == 0 {
+				continue
+			}
+			v.dataFileAccessLock.Lock()
+			end, _, e := v.DataBackend.GetStat()
+			if e != nil {
+				for i := 0; i < len(currentRequests); i++ {
+					currentRequests[i].Complete(0, 0, false,
+						fmt.Errorf("cannot read current volume position: %v", e))
+				}
+				v.dataFileAccessLock.Unlock()
+				continue
+			}
+
+			for i := 0; i < len(currentRequests); i++ {
+				if currentRequests[i].IsWriteRequest {
+					offset, size, isUnchanged, err := v.doWriteRequest(currentRequests[i].N)
+					currentRequests[i].UpdateResult(offset, uint64(size), isUnchanged, err)
+				} else {
+					size, err := v.doDeleteRequest(currentRequests[i].N)
+					currentRequests[i].UpdateResult(0, uint64(size), false, err)
+				}
+			}
+
+			if fsync {
+				// if sync error, data is not reliable, we should mark the completed request as fail and rollback
+				if err := v.DataBackend.Sync(); err != nil {
+					// todo: this may generate dirty data or cause data inconsistent, may be weed need to panic?
+					if te := v.DataBackend.Truncate(end); te != nil {
+						glog.V(0).Infof("Failed to truncate %s back to %d with error: %v", v.DataBackend.Name(), end, te)
+					}
+					for i := 0; i < len(currentRequests); i++ {
+						if currentRequests[i].IsSucceed() {
+							currentRequests[i].UpdateResult(0, 0, false, err)
+						}
+					}
+				}
+			}
+
+			for i := 0; i < len(currentRequests); i++ {
+				currentRequests[i].Submit()
+			}
+			v.dataFileAccessLock.Unlock()
+		}
+	}()
 }
 
 type VolumeFileScanner interface {


### PR DESCRIPTION
Seaweedfs not flush data to disk default, this is not safe and may limit its usage scenarios.

The latest patch add fsync option in request, but it lead to great performance degradation.

In most cases, storage system use bin log to balance performance and data security, such as ceph filestore and hbase, but this just suitable for small object, its double write also lead to performance degradation for BLOB(especially for object large than 50KB), such as ceph filestore get poor performance when write large files.

We can do better for seaweedfs, since all seaweedfs write/delete is append mode. Its IO pattern 
is as same as bin log. So we can write seaweedfs just as write bin log in other storage system to receive both good performance and data security.

here is some tests for compare:
1. without this patch
benchmark 10k(file size) files without fsync:
Concurrency Level:      1024
Time taken for tests:   47.402 seconds
Complete requests:      1000000
Failed requests:        0
Total transferred:      10031516643 bytes
Requests per second:    21095.99 [#/sec]
Transfer rate:          206664.79 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        0.4      47.9       187.1      15.2

Percentage of the requests served within a certain time (ms)
   50%     45.7 ms
   66%     51.1 ms
   75%     56.5 ms
   80%     59.1 ms
   90%     65.7 ms
   95%     75.4 ms
   98%     85.7 ms
   99%     92.6 ms
  100%    187.1 ms

benchmark 50k(file size) files without fsync::
Concurrency Level:      1024
Time taken for tests:   113.247 seconds
Complete requests:      500000
Failed requests:        0
Total transferred:      25015746012 bytes
Requests per second:    4415.14 [#/sec]
Transfer rate:          215719.01 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        0.6      230.6       3493.9      291.2

Percentage of the requests served within a certain time (ms)
   50%    115.5 ms
   66%    244.9 ms
   75%    352.8 ms
   80%    427.9 ms
   90%    644.1 ms
   95%    858.6 ms
   98%    1097.6 ms
   99%    1215.7 ms
  100%    3493.9 ms

benchmark 10k(file size) files with fsync
Concurrency Level:      1024
Time taken for tests:   9.466 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      100311726 bytes
Requests per second:    1056.46 [#/sec]
Transfer rate:          10349.17 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        4.1      906.6       2381.5      248.5

Percentage of the requests served within a certain time (ms)
   50%    916.7 ms
   66%    983.8 ms
   75%    1028.7 ms
   80%    1065.7 ms
   90%    1238.4 ms
   95%    1318.9 ms
   98%    1391.2 ms
   99%    1426.5 ms
  100%    2381.5 ms

benchmark 50k(file size) files with fsync：
Concurrency Level:      1024
Time taken for tests:   22.547 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      500315101 bytes
Requests per second:    443.51 [#/sec]
Transfer rate:          21669.41 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        13.2      2170.6       3571.0      661.6

Percentage of the requests served within a certain time (ms)
   50%    2265.3 ms
   66%    2441.5 ms
   75%    2556.6 ms
   80%    2665.9 ms
   90%    2960.1 ms
   95%    3152.2 ms
   98%    3281.4 ms
   99%    3348.2 ms
  100%    3571.0 ms

2. with this patch
benchmark 10k(file size) files without fsync
 (note:this patch not provide a option for fsync, this test just comment code of fsync. The fsync option will commit at next patch, which privode fsync option on collection instead of file)：

Concurrency Level:      1024
Time taken for tests:   47.193 seconds
Complete requests:      1000000
Failed requests:        0
Total transferred:      10031499245 bytes
Requests per second:    21189.52 [#/sec]
Transfer rate:          207580.72 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        0.5      47.7       187.9      15.7

Percentage of the requests served within a certain time (ms)
   50%     46.0 ms
   66%     50.1 ms
   75%     55.7 ms
   80%     59.6 ms
   90%     66.8 ms
   95%     75.1 ms
   98%     87.2 ms
   99%     93.8 ms
  100%    187.9 ms

benchmark 50k(file size) files without fsync：
Concurrency Level:      1024
Time taken for tests:   201.355 seconds
Complete requests:      1000000
Failed requests:        0
Total transferred:      50031511258 bytes
Requests per second:    4966.36 [#/sec]
Transfer rate:          242650.77 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        0.6      204.7       2361.6      336.3

Percentage of the requests served within a certain time (ms)
   50%     15.0 ms
   66%    140.2 ms
   75%    299.2 ms
   80%    403.2 ms
   90%    705.9 ms
   95%    963.0 ms
   98%    1228.0 ms
   99%    1389.4 ms
  100%    2361.6 ms

benchmark 10k(file size) files with fsync(current implementation):
Concurrency Level:      1024
Time taken for tests:   191.591 seconds
Complete requests:      1000000
Failed requests:        0
Total transferred:      10031526403 bytes
Requests per second:    5219.46 [#/sec]
Transfer rate:          51131.96 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        1.2      196.0       717.7      98.3

Percentage of the requests served within a certain time (ms)
   50%    188.6 ms
   66%    237.1 ms
   75%    266.9 ms
   80%    285.0 ms
   90%    329.9 ms
   95%    364.2 ms
   98%    404.8 ms
   99%    434.2 ms
  100%    717.7 ms

benchmark 50k(file size) files with fsync(current implementation):
Concurrency Level:      1024
Time taken for tests:   46.951 seconds
Complete requests:      100000
Failed requests:        0
Total transferred:      5003151387 bytes
Requests per second:    2129.90 [#/sec]
Transfer rate:          104064.61 [Kbytes/sec]

Connection Times (ms)
              min      avg        max      std
Total:        28.0      478.5       1212.3      166.1

Percentage of the requests served within a certain time (ms)
   50%    452.9 ms
   66%    518.0 ms
   75%    561.9 ms
   80%    598.5 ms
   90%    696.3 ms
   95%    810.6 ms
   98%    909.4 ms
   99%    987.4 ms
  100%    1212.3 ms


With this patch, the performance is up to x5 in fsync mode, and the performance  has no obvious difference without fsync.

TODO List:
a. provide fsync option on collection instead of file;
b. verify data consistency during volume load；