### PR TITLE
Return NotSuchKey error code for bucket S3 DeleteObject method

### DIFF
--- a/weed/s3api/s3api_errors.go
+++ b/weed/s3api/s3api_errors.go
@@ -33,6 +33,7 @@ const (
 	ErrBucketAlreadyExists
 	ErrBucketAlreadyOwnedByYou
 	ErrNoSuchBucket
+	ErrNoSuchKey
 	ErrNoSuchUpload
 	ErrInvalidBucketName
 	ErrInvalidDigest
@@ -132,6 +133,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrNoSuchBucket: {
 		Code:           "NoSuchBucket",
 		Description:    "The specified bucket does not exist",
+		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrNoSuchKey: {
+		Code:           "NoSuchKey",
+		Description:    "The specified key does not exist.",
 		HTTPStatusCode: http.StatusNotFound,
 	},
 	ErrNoSuchUpload: {

--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"google.golang.org/grpc"
@@ -76,13 +77,19 @@ func getRESTErrorResponse(err APIError, resource string) RESTErrorResponse {
 
 func writeResponse(w http.ResponseWriter, statusCode int, response []byte, mType mimeType) {
 	setCommonHeaders(w)
+	if response != nil {
+		w.Header().Set("Content-Length", strconv.Itoa(len(response)))
+	}
 	if mType != mimeNone {
 		w.Header().Set("Content-Type", string(mType))
 	}
 	w.WriteHeader(statusCode)
 	if response != nil {
 		glog.V(4).Infof("status %d %s: %s", statusCode, mType, string(response))
-		w.Write(response)
+		_, err := w.Write(response)
+		if err != nil {
+			glog.V(0).Infof("write err: %v", err)
+		}
 		w.(http.Flusher).Flush()
 	}
 }

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -112,11 +112,7 @@ func (s3a *S3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Reque
 		for k, v := range proxyResponse.Header {
 			w.Header()[k] = v
 		}
-		if proxyResponse.StatusCode == http.StatusNotFound {
-			writeErrorResponse(w, ErrNoSuchKey, r.URL)
-			return
-		}
-		w.WriteHeader(proxyResponse.StatusCode)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 }

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
-	"github.com/chrislusf/seaweedfs/weed/server"
+	weed_server "github.com/chrislusf/seaweedfs/weed/server"
 	"github.com/chrislusf/seaweedfs/weed/util"
 )
 
@@ -108,11 +108,11 @@ func (s3a *S3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Reque
 	destUrl := fmt.Sprintf("http://%s%s/%s%s",
 		s3a.option.Filer, s3a.option.BucketsPath, bucket, object)
 
-	s3a.proxyToFiler(w, r, destUrl, func(proxyResonse *http.Response, w http.ResponseWriter) {
-		for k, v := range proxyResonse.Header {
+	s3a.proxyToFiler(w, r, destUrl, func(proxyResponse *http.Response, w http.ResponseWriter) {
+		for k, v := range proxyResponse.Header {
 			w.Header()[k] = v
 		}
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(proxyResponse.StatusCode)
 	})
 
 }

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -112,6 +112,10 @@ func (s3a *S3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Reque
 		for k, v := range proxyResponse.Header {
 			w.Header()[k] = v
 		}
+		if proxyResponse.StatusCode == http.StatusNotFound {
+			writeErrorResponse(w, ErrNoSuchKey, r.URL)
+			return
+		}
 		w.WriteHeader(proxyResponse.StatusCode)
 	})
 


### PR DESCRIPTION
Fixes for S3 DeleteObject

* return 404 status code instead of 204 No content
* return xml encoded error with code `NoSuchKey`

Sample s3 response:
```
curl -v -X DELETE localhost:8333/not/exist
*   Trying ::1:8333...
* TCP_NODELAY set
* Connected to localhost (::1) port 8333 (#0)
> DELETE /not/exist HTTP/1.1
> Host: localhost:8333
> User-Agent: curl/7.68.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< Accept-Ranges: bytes
< Content-Length: 201
< Content-Type: application/xml
< Date: Thu, 11 Jun 2020 14:56:48 GMT
< X-Amz-Request-Id: 1591887408636162435
<
<?xml version="1.0" encoding="UTF-8"?>
* Connection #0 to host localhost left intact
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Resource>/not/exist</Resource><RequestId>1591887408636143362</RequestId></Error>
```