### PR TITLE
Return last modified in UTC

### DIFF
--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -138,7 +138,7 @@ func (s3a *S3ApiServer) listFilerEntries(bucket, originalPrefix string, maxKeys 
 			} else {
 				contents = append(contents, ListEntry{
 					Key:          fmt.Sprintf("%s%s", dir, entry.Name),
-					LastModified: time.Unix(entry.Attributes.Mtime, 0),
+					LastModified: time.Unix(entry.Attributes.Mtime, 0).UTC(),
 					ETag:         "\"" + filer2.ETag(entry) + "\"",
 					Size:         int64(filer2.TotalSize(entry.Chunks)),
 					Owner: CanonicalUser{


### PR DESCRIPTION
AWS SDK expects LastModified time encoded in UTC:

```
        <*awserr.requestError | 0xc00039bd00>: {
            awsError: {
                code: "SerializationError",
                message: "failed to decode REST XML response",
                errs: [
                    {
                        Layout: "2006-01-02T15:04:05.999999999Z",
                        Value: "2020-06-19T06:56:55+03:00",
                        LayoutElem: "Z",
                        ValueElem: "+03:00",
                        Message: "",
                    },
                ],
            },
            statusCode: 200,
            requestID: "1592539015628364172",
            bytes: nil,
        }
        SerializationError: failed to decode REST XML response
                status code: 200, request id: 1592539015628364172
        caused by: parsing time "2020-06-19T06:56:55+03:00" as "2006-01-02T15:04:05.999999999Z": cannot parse "+03:00" as "Z"
```