### PR TITLE
Optional md5 validation of uploads

### DIFF
--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -103,9 +103,7 @@ type ChecksumReader struct {
 
 func (cr *ChecksumReader) Read(p []byte) (int, error) {
 	n, err := cr.r.Read(p)
-	if err == nil {
-		cr.h.Write(p[:n])
-	}
+	cr.h.Write(p[:n])
 	return n, err
 }
 

--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -1,10 +1,8 @@
 package needle
 
 import (
-	"compress/gzip"
 	"crypto/md5"
 	"fmt"
-	"hash"
 	"io"
 	"io/ioutil"
 	"mime"

--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -140,7 +140,7 @@ func parseMultipart(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error
 
 	reader := io.LimitReader(part, sizeLimit+1)
 	if expectedChecksum := r.Header.Get("Content-MD5"); expectedChecksum != "" {
-		if part.Header.Get("Content-Encoding") == "gzip" {
+		if r.Header.Get("Content-Encoding") == "gzip" {
 			gr, err := gzip.NewReader(reader)
 			if err != nil {
 				e = fmt.Errorf("Content-Encoding == gzip but content was not gzipped: %s", err)


### PR DESCRIPTION
We would like to add this due to #1370 

If the Content-MD5 header is set profiling shows the md5 compute uses a significant amount of the total cpu but as its optional it can be avoided. 
