### PR TITLE
Support multiple architectures when building Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,13 @@
-FROM frolvlad/alpine-glibc
+FROM gronis/alpine-glibc
 
-# Supercronic install settings
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.8/supercronic-linux-amd64 \
-    SUPERCRONIC=supercronic-linux-amd64 \
-    SUPERCRONIC_SHA1SUM=be43e64c45acd6ec4fce5831e03759c89676a0ea
-
-# Install SeaweedFS and Supercronic ( for cron job mode )
-# Tried to use curl only (curl -o /tmp/linux_amd64.tar.gz ...), however it turned out that the following tar command failed with "gzip: stdin: not in gzip format"
-RUN apk add --no-cache --virtual build-dependencies --update wget curl ca-certificates && \
-    wget -P /tmp https://github.com/$(curl -s -L https://github.com/chrislusf/seaweedfs/releases/latest | egrep -o 'chrislusf/seaweedfs/releases/download/.*/linux_amd64.tar.gz') && \
-    tar -C /usr/bin/ -xzvf /tmp/linux_amd64.tar.gz && \
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g' | sed 's/armv7l/arm/g') && \
+    SUPERCRONIC_SHA1SUM=$(echo $ARCH | sed 's/amd64/5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85/g' | sed 's/arm64/e2714c43e7781bf1579c85aa61259245f56dbba1/g' | sed 's/arm/47481c3341bc3a1ae91a728e0cc63c8e6d3791ad/g') && \
+    SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-$ARCH && \
+    SUPERCRONIC=supercronic-linux-$ARCH && \
+    # Install SeaweedFS and Supercronic ( for cron job mode )
+    apk add --no-cache --virtual build-dependencies --update wget curl ca-certificates && \
+    wget -P /tmp https://github.com/$(curl -s -L https://github.com/chrislusf/seaweedfs/releases/latest | egrep -o "chrislusf/seaweedfs/releases/download/.*/linux_$ARCH.tar.gz") && \
+    tar -C /usr/bin/ -xzvf /tmp/linux_$ARCH.tar.gz && \
     curl -fsSLO "$SUPERCRONIC_URL" && \
     echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - && \
     chmod +x "$SUPERCRONIC" && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,13 @@
-FROM gronis/alpine-glibc
+FROM alpine
 
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g' | sed 's/armv7l/arm/g') && \
-    SUPERCRONIC_SHA1SUM=$(echo $ARCH | sed 's/amd64/5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85/g' | sed 's/arm64/e2714c43e7781bf1579c85aa61259245f56dbba1/g' | sed 's/arm/47481c3341bc3a1ae91a728e0cc63c8e6d3791ad/g') && \
+RUN \
+    ARCH=$(if [ $(uname -m) == "x86_64" ] && [ $(getconf LONG_BIT) == "64" ]; then echo "amd64"; \
+         elif [ $(uname -m) == "x86_64" ] && [ $(getconf LONG_BIT) == "32" ]; then echo "386"; \
+         elif [ $(uname -m) == "aarch64" ]; then echo "arm64"; \
+         elif [ $(uname -m) == "armv7l" ]; then echo "arm"; \
+         elif [ $(uname -m) == "armv6l" ]; then echo "arm"; fi;) && \
+    echo "Building for $ARCH" 1>&2 && \
+    SUPERCRONIC_SHA1SUM=$(echo $ARCH | sed 's/386/e0126b0102b9f388ecd55714358e3ad60d0cebdb/g' | sed 's/amd64/5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85/g' | sed 's/arm64/e2714c43e7781bf1579c85aa61259245f56dbba1/g' | sed 's/arm/47481c3341bc3a1ae91a728e0cc63c8e6d3791ad/g') && \
     SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-$ARCH && \
     SUPERCRONIC=supercronic-linux-$ARCH && \
     # Install SeaweedFS and Supercronic ( for cron job mode )

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,7 +30,10 @@ make
 
 ## Build and push a multiarch build
 
-Make sure that `docker buildx` is supported.
+Make sure that `docker buildx` is supported (might be an experimental docker feature)
 ```bash
+BUILDER=$(docker buildx create --driver docker-container --use)
 docker buildx build --pull --push --platform linux/386,linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 . -t chrislusf/seaweedfs
+docker buildx stop $BUILDER
 ```
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,3 +27,10 @@ docker-compose -f seaweedfs-dev-compose.yml -p seaweedfs up
 cd $GOPATH/src/github.com/chrislusf/seaweedfs/docker
 make
 ```
+
+## Build and push a multiarch build
+
+Make sure that `docker buildx` is supported.
+```bash
+docker buildx build --pull --push --platform linux/386,linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 . -t chrislusf/seaweedfs
+```


### PR DESCRIPTION
Add support for the following cpu architectures when building the Dockerfile:
- i386
- arm64
- armv6
- armv7

Update readme with instructions to build and push all cpu architectures at the same time.