### PR TITLE
add 5-byte large disk builds for arm and arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,14 @@ release: deps windows_build darwin_build linux_build bsd_build 5_byte_linux_buil
 	$(call build_large,windows,amd64,.exe)
 	$(call zip_large,windows,amd64,.exe)
 
+5_byte_arm_build: $(sources)
+	$(call build_large,linux,arm,)
+	$(call tar_large,linux,arm)
+
+5_byte_arm64_build: $(sources)
+	$(call build_large,linux,arm64,)
+	$(call tar_large,linux,arm64)
+
 linux_build: build/linux_arm.tar.gz build/linux_arm64.tar.gz build/linux_386.tar.gz build/linux_amd64.tar.gz
 
 build/linux_386.tar.gz: $(sources)

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ linux: deps
 	mkdir -p linux
 	GOOS=linux GOARCH=amd64 go build $(GO_FLAGS) -ldflags "$(LDFLAGS)" -o linux/$(BINARY) $(SOURCE_DIR)
 
-release: deps windows_build darwin_build linux_build bsd_build 5_byte_linux_build 5_byte_darwin_build 5_byte_windows_build
+release: deps windows_build darwin_build linux_build bsd_build 5_byte_linux_build 5_byte_arm64_build 5_byte_darwin_build 5_byte_windows_build
 
 ##### LINUX BUILDS #####
 5_byte_linux_build:


### PR DESCRIPTION
I have Odroid HC2s with 12TB drives in them, so running the 5-byte build of SeaweedFS seemed correct. 