### PR TITLE
volume: Don't unmount before deleting volume in copy

### DIFF
--- a/weed/server/volume_grpc_copy.go
+++ b/weed/server/volume_grpc_copy.go
@@ -27,17 +27,12 @@ func (vs *VolumeServer) VolumeCopy(ctx context.Context, req *volume_server_pb.Vo
 
 		glog.V(0).Infof("volume %d already exists. deleted before copying...", req.VolumeId)
 
-		err := vs.store.UnmountVolume(needle.VolumeId(req.VolumeId))
-		if err != nil {
-			return nil, fmt.Errorf("failed to mount existing volume %d: %v", req.VolumeId, err)
-		}
-
-		err = vs.store.DeleteVolume(needle.VolumeId(req.VolumeId))
+		err := vs.store.DeleteVolume(needle.VolumeId(req.VolumeId))
 		if err != nil {
 			return nil, fmt.Errorf("failed to delete existing volume %d: %v", req.VolumeId, err)
 		}
 
-		glog.V(0).Infof("deleted exisitng volume %d before copying.", req.VolumeId)
+		glog.V(0).Infof("deleted existing volume %d before copying.", req.VolumeId)
 	}
 
 	location := vs.store.FindFreeLocation()

--- a/weed/storage/disk_location.go
+++ b/weed/storage/disk_location.go
@@ -174,6 +174,9 @@ func (l *DiskLocation) DeleteCollectionFromDiskLocation(collection string) (e er
 }
 
 func (l *DiskLocation) deleteVolumeById(vid needle.VolumeId) (found bool, e error) {
+	l.volumesLock.Lock()
+	defer l.volumesLock.Unlock()
+
 	v, ok := l.volumes[vid]
 	if !ok {
 		return

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -380,7 +380,7 @@ func (s *Store) DeleteVolume(i needle.VolumeId) error {
 		Ttl:              v.Ttl.ToUint32(),
 	}
 	for _, location := range s.Locations {
-		if found, error := location.deleteVolumeById(i); found && error == nil {
+		if found, err := location.deleteVolumeById(i); found && err == nil {
 			glog.V(0).Infof("DeleteVolume %d", i)
 			s.DeletedVolumesChan <- message
 			return nil


### PR DESCRIPTION
If we unmount first and then delete, the delete fails because the volume was unmounted. Delete ends up doing the same thing as the unmount anyways.