### PR TITLE
s3:  fix get object metadata problem

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -265,7 +265,7 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 
 	resp, postErr := client.Do(proxyReq)
 
-	if resp.ContentLength == -1 {
+	if resp.ContentLength == -1 && !strings.HasSuffix(destUrl, "/") {
 		writeErrorResponse(w, s3err.ErrNoSuchKey, r.URL)
 		return
 	}


### PR DESCRIPTION

1. spark 通过binaryFiles读取目录及目录通配符情况下会报错

**复现：**
```
scala> sc.hadoopConfiguration.set("fs.s3a.access.key", "xxx")
scala> sc.hadoopConfiguration.set("fs.s3a.secret.key", "xxx")
scala> sc.hadoopConfiguration.set("fs.s3a.impl","org.apache.hadoop.fs.s3a.S3AFileSystem")
scala> sc.hadoopConfiguration.set("fs.s3a.endpoint", "http://127.0.0.1:8333")

scala> val a = sc.binaryFiles("s3a://limd/aaa/*")  //以目录结尾、通配符结尾都会报错
a: org.apache.spark.rdd.RDD[(String, org.apache.spark.input.PortableDataStream)] = s3a://limd/aaa/* BinaryFileRDD[5] at binaryFiles at <console>:24

scala> a.count
org.apache.hadoop.mapreduce.lib.input.InvalidInputException: Input Pattern s3a://limd/aaa/* matches 0 files
  at org.apache.hadoop.mapreduce.lib.input.FileInputFormat.singleThreadedListStatus(FileInputFormat.java:332)
  at org.apache.hadoop.mapreduce.lib.input.FileInputFormat.listStatus(FileInputFormat.java:274)
  at org.apache.spark.input.StreamFileInputFormat.setMinPartitions(PortableDataStream.scala:51)
  at org.apache.spark.rdd.BinaryFileRDD.getPartitions(BinaryFileRDD.scala:51)
  at org.apache.spark.rdd.RDD.$anonfun$partitions$2(RDD.scala:276)
  at scala.Option.getOrElse(Option.scala:189)
  at org.apache.spark.rdd.RDD.partitions(RDD.scala:272)
  at org.apache.spark.SparkContext.runJob(SparkContext.scala:2158)
  at org.apache.spark.rdd.RDD.count(RDD.scala:1227)
  ... 47 elided

```


2. spark history服务event log配置s3会报no such file or directory: s3a://limd/aaa

**分析**

spark history server中会通过此方法判断是否目录
```
protected def requireLogBaseDirAsDirectory(): Unit = {
    if (!fileSystem.getFileStatus(new Path(logBaseDir)).isDirectory) {
      throw new IllegalArgumentException(s"Log directory $logBaseDir is not a directory.")
    }
  }
```

该方法会调用s3的getObjectMetadata方法


**复现：**
```
        GetObjectMetadataRequest request = new GetObjectMetadataRequest(bucketName, "aaa/");
        s3.getObjectMetadata(request);
```


根据对比minio，获取元数据为目录情况下会返回NoSuchKey

minio:
           目录为aaa 返回NoSuchKey
           目录为aaa/ 正常返回

seaweedfs：
           目录为aaa 返回NoSuchKey
           目录为aaa/ 返回NoSuchKey

修改返回结构和minio一致，请作者参考
