### PR TITLE
We return etag using the same algorithm as aws s3

### DIFF
--- a/weed/server/volume_server_handlers_write.go
+++ b/weed/server/volume_server_handlers_write.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chrislusf/seaweedfs/weed/stats"
 	"github.com/chrislusf/seaweedfs/weed/storage/needle"
 	"github.com/chrislusf/seaweedfs/weed/topology"
+	"github.com/chrislusf/seaweedfs/weed/util"
 )
 
 func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
@@ -67,7 +68,7 @@ func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
 		ret.Name = string(reqNeedle.Name)
 	}
 	ret.Size = uint32(originalSize)
-	ret.ETag = reqNeedle.Etag()
+	ret.ETag = fmt.Sprintf("%x", util.Base64Md5ToBytes(contentMd5))
 	ret.Mime = string(reqNeedle.Mime)
 	setEtag(w, ret.ETag)
 	w.Header().Set("Content-MD5", contentMd5)


### PR DESCRIPTION
See [All about AWS S3 ETags](https://teppen.io/2018/06/23/aws_s3_etags/)

Necessary for
```
aws --endpoint-url http://localhost:8333/ s3 sync s3://my-us-west-2-bucket  s3://seaweedfs-bucket --source-region us-west-2
```