### PR TITLE
Run go test on gituh actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,4 +34,4 @@ jobs:
       run: cd weed; go build -v .
 
     - name: Test
-      run: cd weed; go test -v .
+      run: cd weed; go test -v ./...


### PR DESCRIPTION
Currently the go workflows only try to run tests in the weed module, make it so it runs them recursively.