### PR TITLE
Run go test on github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,4 +34,4 @@ jobs:
       run: cd weed; go build -v .
 
     - name: Test
-      run: cd weed; go test -v .
+      run: go test -v ./...


### PR DESCRIPTION
Currently the go workflows only try to run tests in the weed module (non-recursive), make it so it runs them recursively over the repository.
