### PR TITLE
Allow custom command arguments to override default values in docker

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,7 +23,8 @@ case "$1" in
 
   'master')
   	ARGS="-mdir=/data -volumePreallocate -volumeSizeLimitMB=1024"
-  	exec /usr/bin/weed $@ $ARGS
+  	shift
+  	exec /usr/bin/weed master $ARGS $@
 	;;
 
   'volume')
@@ -31,7 +32,8 @@ case "$1" in
   	if isArgPassed "-max" "$@"; then
   	  ARGS="-dir=/data"
   	fi
-  	exec /usr/bin/weed $@ $ARGS
+  	shift
+  	exec /usr/bin/weed volume $ARGS $@
 	;;
 
   'server')
@@ -39,17 +41,20 @@ case "$1" in
   	if isArgPassed "-volume.max" "$@"; then
   	  ARGS="-dir=/data -master.volumePreallocate -master.volumeSizeLimitMB=1024"
   	fi
-  	exec /usr/bin/weed $@ $ARGS
+ 	shift
+  	exec /usr/bin/weed server $ARGS $@
   	;;
 
   'filer')
   	ARGS=""
-  	exec /usr/bin/weed $@ $ARGS
+  	shift
+  	exec /usr/bin/weed filer $ARGS $@
 	;;
 
   's3')
   	ARGS="-domainName=$S3_DOMAIN_NAME -key.file=$S3_KEY_FILE -cert.file=$S3_CERT_FILE"
-  	exec /usr/bin/weed $@ $ARGS
+  	shift
+  	exec /usr/bin/weed s3 $ARGS $@
 	;;
 
   'cronjob')


### PR DESCRIPTION
Depending on a setup, 1GB volume limit is not the preferable size.
As weed can process multiple arguements and the later argument is the one to be used,
it is relatively easy to override the arguments defined in the entrypoint.

The arguments passed to the script will be shifted and appended at the end of the command. Since the first argument will fall into specific case, the argument can be predefined and the whole argument array shifted. Allowing to do "volume/server/master/etc $ARGS $@"