### PR TITLE
Dockerfile: support build branches other than master 

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -2,6 +2,8 @@ FROM frolvlad/alpine-glibc as builder
 RUN apk add git go g++
 RUN mkdir -p /go/src/github.com/chrislusf/
 RUN git clone https://github.com/chrislusf/seaweedfs /go/src/github.com/chrislusf/seaweedfs
+ARG branch=${branch:-master}
+RUN cd /go/src/github.com/chrislusf/seaweedfs && git checkout $ARG
 RUN cd /go/src/github.com/chrislusf/seaweedfs/weed \
   && export LDFLAGS="-X github.com/chrislusf/seaweedfs/weed/util.COMMIT=$(git rev-parse --short HEAD)" \
   && go install -ldflags "${LDFLAGS}"

--- a/docker/Dockerfile.go_build_large
+++ b/docker/Dockerfile.go_build_large
@@ -2,6 +2,8 @@ FROM frolvlad/alpine-glibc as builder
 RUN apk add git go g++
 RUN mkdir -p /go/src/github.com/chrislusf/
 RUN git clone https://github.com/chrislusf/seaweedfs /go/src/github.com/chrislusf/seaweedfs
+ARG branch=${branch:-master}
+RUN cd /go/src/github.com/chrislusf/seaweedfs && git checkout $ARG
 RUN cd /go/src/github.com/chrislusf/seaweedfs/weed \
   && export LDFLAGS="-X github.com/chrislusf/seaweedfs/weed/util.COMMIT=$(git rev-parse --short HEAD)" \
   && go install -tags 5BytesOffset -ldflags "${LDFLAGS}"


### PR DESCRIPTION
by using --build-args
example:
`docker build --build-arg BRANCH=support_ssd_volume -t seaweedfs:ssd_support .`

will build the support_ssd_volume branch and not the master