### PR TITLE
[shell] Clarify bucket replication setting order

### DIFF
--- a/weed/shell/command_s3_bucket_create.go
+++ b/weed/shell/command_s3_bucket_create.go
@@ -34,7 +34,9 @@ func (c *commandS3BucketCreate) Do(args []string, commandEnv *CommandEnv, writer
 
 	bucketCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	bucketName := bucketCommand.String("name", "", "bucket name")
-	replication := bucketCommand.String("replication", "", "replication setting for the bucket, if not set it will honor the setting defined by the filer or master")
+	replication := bucketCommand.String("replication", "", "replication setting for the bucket, if not set "+
+		"it will honor the value defined by the filer if it exists, "+
+		"else it will honor the value defined on the master")
 	if err = bucketCommand.Parse(args); err != nil {
 		return nil
 	}


### PR DESCRIPTION
sentence "defined by the filer or master" implies there is no particular order. attempting to clarify that.

Not sure how the long string in multiline will render in a small terminal 