### PR TITLE
Add fuse to all dockerfiles

### DIFF
--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -14,6 +14,7 @@ COPY --from=builder /root/go/bin/weed /usr/bin/
 RUN mkdir -p /etc/seaweedfs
 COPY --from=builder /go/src/github.com/chrislusf/seaweedfs/docker/filer.toml /etc/seaweedfs/filer.toml
 COPY --from=builder /go/src/github.com/chrislusf/seaweedfs/docker/entrypoint.sh /entrypoint.sh
+RUN apk add fuse # for weed mount
 
 # volume server gprc port
 EXPOSE 18080

--- a/docker/Dockerfile.go_build_large
+++ b/docker/Dockerfile.go_build_large
@@ -14,6 +14,7 @@ COPY --from=builder /root/go/bin/weed /usr/bin/
 RUN mkdir -p /etc/seaweedfs
 COPY --from=builder /go/src/github.com/chrislusf/seaweedfs/docker/filer.toml /etc/seaweedfs/filer.toml
 COPY --from=builder /go/src/github.com/chrislusf/seaweedfs/docker/entrypoint.sh /entrypoint.sh
+RUN apk add fuse # for weed mount
 
 # volume server gprc port
 EXPOSE 18080

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -4,6 +4,7 @@ COPY  ./weed /usr/bin/
 RUN mkdir -p /etc/seaweedfs
 COPY ./filer.toml /etc/seaweedfs/filer.toml
 COPY ./entrypoint.sh /entrypoint.sh
+RUN apk add fuse # for weed mount
 
 # volume server grpc port
 EXPOSE 18080


### PR DESCRIPTION
I noticed `weed mount` wasn't working with a tagged docker image, because https://github.com/chrislusf/seaweedfs/pull/1690 only added fuse to the `latest` build. This should add fuse to all builds. Also, I was wrong about it adding <1mb. It seems to add 6.5mb to the final image (89.3mb vs 81.8mb), but this probably isn't a concern for someone running a distributed filesystem.