### PR TITLE
filer: Fix prefix matching (#1722)

### DIFF
--- a/weed/filer/leveldb/leveldb_store.go
+++ b/weed/filer/leveldb/leveldb_store.go
@@ -175,7 +175,7 @@ func (store *LevelDBStore) ListDirectoryPrefixedEntries(ctx context.Context, ful
 	for iter.Next() {
 		key := iter.Key()
 		if !bytes.HasPrefix(key, directoryPrefix) {
-			break
+			continue
 		}
 		fileName := getNameFromKey(key)
 		if fileName == "" {

--- a/weed/filer/leveldb2/leveldb2_store.go
+++ b/weed/filer/leveldb2/leveldb2_store.go
@@ -185,7 +185,7 @@ func (store *LevelDB2Store) ListDirectoryPrefixedEntries(ctx context.Context, fu
 	for iter.Next() {
 		key := iter.Key()
 		if !bytes.HasPrefix(key, directoryPrefix) {
-			break
+			continue
 		}
 		fileName := getNameFromKey(key)
 		if fileName == "" {

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -61,7 +61,7 @@ func (fs *FilerServer) ListEntries(req *filer_pb.ListEntriesRequest, stream file
 	lastFileName := req.StartFromFileName
 	includeLastFile := req.InclusiveStartFrom
 	for limit > 0 {
-		entries, err := fs.filer.ListDirectoryEntries(stream.Context(), util.FullPath(req.Directory), lastFileName, includeLastFile, paginationLimit, req.Prefix)
+		entries, err := fs.filer.ListDirectoryEntries(stream.Context(), util.FullPath(req.Directory), lastFileName, includeLastFile, paginationLimit, fmt.Sprintf("%s*", req.Prefix))
 
 		if err != nil {
 			return err


### PR DESCRIPTION
* `ListDirectoryEntries` takes a pattern, not a prefix, thus to match a
  prefix we have to include a wildcard character `*`
* In the prefix match implementations in leveldb and leveldb2, we should
  continue instead of stop if the current entry does not match the
  prefix.

Note: **please take a close look at this before merging**. I have no idea how filer stores work and my fix could be totally incorrect.