### PR TITLE
impl: TTL per entry for rocksdb; fix package name

### DIFF
--- a/weed/filer/rocksdb/rocksdb_ttl.go
+++ b/weed/filer/rocksdb/rocksdb_ttl.go
@@ -1,0 +1,41 @@
+//+build rocksdb
+
+package rocksdb
+
+import (
+	"time"
+
+	"github.com/tecbot/gorocksdb"
+
+	"github.com/chrislusf/seaweedfs/weed/filer"
+)
+
+type TTLFilter struct {
+	skipLevel0 bool
+}
+
+func NewTTLFilter() gorocksdb.CompactionFilter {
+	return &TTLFilter{
+		skipLevel0: true,
+	}
+}
+
+func (t *TTLFilter) Filter(level int, key, val []byte) (remove bool, newVal []byte) {
+	// decode could be slow, causing write stall
+	// level >0 sst can run compaction in parallel
+	if t.skipLevel0 && level == 0 {
+		return false, val
+	}
+	entry := filer.Entry{}
+	if err := entry.DecodeAttributesAndChunks(val); err == nil {
+		if entry.TtlSec == 0 ||
+			entry.Crtime.Add(time.Duration(entry.TtlSec)*time.Second).Before(time.Now()) {
+			return false, val
+		}
+	}
+	return true, nil
+}
+
+func (t *TTLFilter) Name() string {
+	return "TTLFilter"
+}

--- a/weed/filer/rocksdb/rocksdb_ttl.go
+++ b/weed/filer/rocksdb/rocksdb_ttl.go
@@ -29,7 +29,7 @@ func (t *TTLFilter) Filter(level int, key, val []byte) (remove bool, newVal []by
 	entry := filer.Entry{}
 	if err := entry.DecodeAttributesAndChunks(val); err == nil {
 		if entry.TtlSec == 0 ||
-			entry.Crtime.Add(time.Duration(entry.TtlSec)*time.Second).Before(time.Now()) {
+			entry.Crtime.Add(time.Duration(entry.TtlSec)*time.Second).After(time.Now()) {
 			return false, val
 		}
 	}


### PR DESCRIPTION
Also remove `MaybeDecompressData` since no Compress performed in `InsertEntry`

Did a quick benchmark on insert gzipped or raw large random values. (rocksdb use snappy by default), 
for values < 10k, raw values are much faster,
for values > 100k, gzipped values are slightly faster, but really close (-10% ~ +15%)