### PR TITLE
fix rocksdb crash when list directory

### DIFF
--- a/weed/filer/rocksdb/rocksdb_store.go
+++ b/weed/filer/rocksdb/rocksdb_store.go
@@ -182,17 +182,9 @@ func enumerate(iter *gorocksdb.Iterator, prefix, lastKey []byte, includeLastKey 
 	} else {
 		iter.Seek(lastKey)
 
-		if !includeLastKey {
-			key := iter.Key().Data()
-
-			if !bytes.HasPrefix(key, prefix) {
-				return nil
-			}
-
-			if bytes.Equal(key, lastKey) {
-				iter.Next()
-			}
-
+		if iter.Valid() && !includeLastKey &&
+			bytes.Equal(iter.Key().Data(), lastKey) {
+			iter.Next()
 		}
 	}
 
@@ -249,10 +241,6 @@ func (store *RocksDBStore) ListDirectoryPrefixedEntries(ctx context.Context, ful
 		fileName := getNameFromKey(key)
 		if fileName == "" {
 			return true
-		}
-		limit--
-		if limit < 0 {
-			return false
 		}
 		entry := &filer.Entry{
 			FullPath: weed_util.NewFullPath(string(fullpath), fileName),

--- a/weed/filer/rocksdb/rocksdb_store.go
+++ b/weed/filer/rocksdb/rocksdb_store.go
@@ -181,10 +181,12 @@ func enumerate(iter *gorocksdb.Iterator, prefix, lastKey []byte, includeLastKey 
 		iter.Seek(prefix)
 	} else {
 		iter.Seek(lastKey)
-
-		if iter.Valid() && !includeLastKey &&
-			bytes.Equal(iter.Key().Data(), lastKey) {
-			iter.Next()
+		if !includeLastKey {
+			if iter.Valid() {
+				if bytes.Equal(iter.Key().Data(), lastKey) {
+					iter.Next()
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
rocksdb iterator `iter.Seek()` may reach EOF,
`iter.Next()` without check could cause segmentation violation.

How to reproduce:
List an invalid directory.

Also remove redundant limit check.