### PR TITLE
Use provided umask on mount

### DIFF
--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -208,7 +208,9 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	})
 
 	glog.V(0).Infof("mounted %s%s to %s", filer, mountRoot, dir)
-	err = fs.Serve(c, seaweedFileSystem)
+	server := fs.New(c, nil)
+	seaweedFileSystem.Server = server
+	err = server.Serve(seaweedFileSystem)
 
 	// check if the mount process has an error to report
 	<-c.Ready

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -100,7 +100,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	uid, gid := uint32(0), uint32(0)
 	mountMode := os.ModeDir | 0777
 	if err == nil {
-		mountMode = os.ModeDir | fileInfo.Mode()
+		mountMode := os.ModeDir | os.FileMode(0777)&^umask
 		uid, gid = util.GetFileUidGid(fileInfo)
 		fmt.Printf("mount point owner uid=%d gid=%d mode=%s\n", uid, gid, fileInfo.Mode())
 	} else {
@@ -208,9 +208,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	})
 
 	glog.V(0).Infof("mounted %s%s to %s", filer, mountRoot, dir)
-	server := fs.New(c, nil)
-	seaweedFileSystem.Server = server
-	err = server.Serve(seaweedFileSystem)
+	err = fs.Serve(c, seaweedFileSystem)
 
 	// check if the mount process has an error to report
 	<-c.Ready

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -102,7 +102,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	if err == nil {
 		mountMode = os.ModeDir | os.FileMode(0777)&^umask
 		uid, gid = util.GetFileUidGid(fileInfo)
-		fmt.Printf("mount point owner uid=%d gid=%d mode=%s\n", uid, gid, fileInfo.Mode())
+		fmt.Printf("mount point owner uid=%d gid=%d mode=%s\n", uid, gid, mountMode)
 	} else {
 		fmt.Printf("can not stat %s\n", dir)
 		return false

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -100,7 +100,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	uid, gid := uint32(0), uint32(0)
 	mountMode := os.ModeDir | 0777
 	if err == nil {
-		mountMode := os.ModeDir | os.FileMode(0777)&^umask
+		mountMode = os.ModeDir | os.FileMode(0777)&^umask
 		uid, gid = util.GetFileUidGid(fileInfo)
 		fmt.Printf("mount point owner uid=%d gid=%d mode=%s\n", uid, gid, fileInfo.Mode())
 	} else {


### PR DESCRIPTION
This PR basically enforces the use of the `-umask` setting provided instead of the one fingerprinted from the OS in case the folder already exists.

Scenario: I'm using the `seaweedfs-csi-plugin` and when `weed mount` is executed with `-dir` pointing to a folder that already exists, the `-umask` setting won't be applied at all. For example: I'm using the `mariadb` docker container which comes with `/var/lib/mysql` already setup in the container and it runs as an unprivileged `mysql` user. When `weed mount` mounts into `/var/lib/mysql`, it is setting the same umask (022) that was predefined in the docker image even when I'm running with `-umask=000`. This causes the container to fail to initialize due to `permission denied` on the folder.

> Note: Tested in my homelab and working as expected