### PR TITLE
Fix EC shard count logic

### DIFF
--- a/weed/topology/data_node_ec.go
+++ b/weed/topology/data_node_ec.go
@@ -25,7 +25,7 @@ func (dn *DataNode) UpdateEcShards(actualShards []*erasure_coding.EcVolumeInfo) 
 
 	existingEcShards := dn.GetEcShards()
 
-	// found out the newShards and deletedShards
+	// find out the newShards and deletedShards
 	var newShardCount, deletedShardCount int
 	for _, ecShards := range existingEcShards {
 
@@ -56,20 +56,19 @@ func (dn *DataNode) UpdateEcShards(actualShards []*erasure_coding.EcVolumeInfo) 
 		disk.UpAdjustDiskUsageDelta(deltaDiskUsages)
 
 	}
+
 	for _, ecShards := range actualShards {
+		if dn.hasEcShards(ecShards.VolumeId) {
+			continue
+		}
+
+		newShards = append(newShards, ecShards)
 
 		disk := dn.getOrCreateDisk(ecShards.DiskType)
 		deltaDiskUsages := newDiskUsages()
 		deltaDiskUsage := deltaDiskUsages.getOrCreateDisk(types.ToDiskType(ecShards.DiskType))
-
-		if !dn.hasEcShards(ecShards.VolumeId) {
-			newShards = append(newShards, ecShards)
-			newShardCount += ecShards.ShardIdCount()
-		}
-
-		deltaDiskUsage.ecShardCount = int64(newShardCount)
+		deltaDiskUsage.ecShardCount = int64(ecShards.ShardIdCount())
 		disk.UpAdjustDiskUsageDelta(deltaDiskUsages)
-
 	}
 
 	if len(newShards) > 0 || len(deletedShards) > 0 {


### PR DESCRIPTION
This fixes the calculation of the amount of EC shards a node holds.
Previously a global counter was increased, but also used inside the
loop to apply disk usage deltas. This led to wrong absolute numbers.
The fix is to apply only deltas of single EC shards per iteration.