### PR TITLE
fix: collection stats won't update if all volumes expired at once

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -220,20 +220,30 @@ func (s *Store) CollectHeartbeat() *master_pb.Heartbeat {
 			if maxFileKey < curMaxFileKey {
 				maxFileKey = curMaxFileKey
 			}
+			deleteVolume := false
 			if !v.expired(volumeMessage.Size, s.GetVolumeSizeLimit()) {
 				volumeMessages = append(volumeMessages, volumeMessage)
 			} else {
 				if v.expiredLongEnough(MAX_TTL_VOLUME_REMOVAL_DELAY) {
 					deleteVids = append(deleteVids, v.Id)
+					deleteVolume = true
 				} else {
 					glog.V(0).Infof("volume %d is expired", v.Id)
 				}
 				if v.lastIoError != nil {
 					deleteVids = append(deleteVids, v.Id)
+					deleteVolume = true
 					glog.Warningf("volume %d has IO error: %v", v.Id, v.lastIoError)
 				}
 			}
-			collectionVolumeSize[v.Collection] += volumeMessage.Size
+
+			if _, exist := collectionVolumeSize[v.Collection]; !exist {
+				collectionVolumeSize[v.Collection] = 0
+			}
+			if !deleteVolume {
+				collectionVolumeSize[v.Collection] += volumeMessage.Size
+			}
+
 			if _, exist := collectionVolumeReadOnlyCount[v.Collection]; !exist {
 				collectionVolumeReadOnlyCount[v.Collection] = map[string]uint8{
 					"IsReadOnly":       0,
@@ -242,7 +252,7 @@ func (s *Store) CollectHeartbeat() *master_pb.Heartbeat {
 					"isDiskSpaceLow":   0,
 				}
 			}
-			if v.IsReadOnly() {
+			if !deleteVolume && v.IsReadOnly() {
 				collectionVolumeReadOnlyCount[v.Collection]["IsReadOnly"] += 1
 				if v.noWriteOrDelete {
 					collectionVolumeReadOnlyCount[v.Collection]["noWriteOrDelete"] += 1
@@ -267,7 +277,7 @@ func (s *Store) CollectHeartbeat() *master_pb.Heartbeat {
 						glog.V(0).Infof("volume %d is deleted", vid)
 					}
 				} else {
-					glog.V(0).Infof("delete volume %d: %v", vid, err)
+					glog.Warningf("delete volume %d: %v", vid, err)
 				}
 			}
 			location.volumesLock.Unlock()


### PR DESCRIPTION
If all volumes in one collection are expired and deleted at once, collection stats won't update until restart or new volume created.
Not a perfect fix if following `deleteVolumeById` goes wrong, stats could be inaccurate anyway.