### PR TITLE
Fix If-Modified-Since behavior

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -311,7 +311,7 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 	}
 	defer util.CloseResponse(resp)
 
-	if resp.ContentLength == -1 || resp.StatusCode == 404 {
+	if (resp.ContentLength == -1 || resp.StatusCode == 404) && resp.StatusCode != 304 {
 		if r.Method != "DELETE" {
 			writeErrorResponse(w, s3err.ErrNoSuchKey, r.URL)
 			return

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -79,7 +79,7 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request, 
 		w.Header().Set("Last-Modified", entry.Attr.Mtime.UTC().Format(http.TimeFormat))
 		if r.Header.Get("If-Modified-Since") != "" {
 			if t, parseError := time.Parse(http.TimeFormat, r.Header.Get("If-Modified-Since")); parseError == nil {
-				if t.After(entry.Attr.Mtime) {
+				if t.After(entry.Attr.Mtime) || t.Equal(entry.Attr.Mtime) {
 					w.WriteHeader(http.StatusNotModified)
 					return
 				}


### PR DESCRIPTION
- `s3api`: passthrough 304 response code from filer, even if `Content-Lenght` is not present
  this bug was leading to 404 responses when passing expired If-Modified-Since   
  
- `filer`: return 304 when `If-Modified-Since` **equal** `Last-Modified`, not only "later"
  as browser saves the time that server returns (using Last-Modified) and uses it with If-Modified-Since on next call
  (note that `volume` handler already behaves this way: https://github.com/chrislusf/seaweedfs/blob/master/weed/server/volume_server_handlers_read.go#L115 )
  
