### PR TITLE
Detect rar archives by mime type

### DIFF
--- a/weed/util/compression.go
+++ b/weed/util/compression.go
@@ -147,6 +147,9 @@ func IsZstdContent(data []byte) bool {
 		if strings.HasSuffix(mtype, "script") {
 			return true, true
 		}
+		if strings.HasSuffix(mtype, "vnd.rar) {
+			return false, true
+		}
 	}
 
 	if strings.HasPrefix(mtype, "audio/") {


### PR DESCRIPTION
RAR archives might not have .rar extension, see [Wikipedia](https://en.wikipedia.org/wiki/RAR_(file_format))