### PR TITLE
make reader_at handle random reads more efficiently for FUSE

### DIFF
--- a/weed/filer/reader_at_test.go
+++ b/weed/filer/reader_at_test.go
@@ -20,6 +20,11 @@ func (m *mockChunkCache) GetChunk(fileId string, minSize uint64) (data []byte) {
 	}
 	return data
 }
+
+func(m *mockChunkCache) GetChunkSlice(fileId string, offset, length uint64) []byte {
+	return nil
+}
+
 func (m *mockChunkCache) SetChunk(fileId string, data []byte) {
 }
 

--- a/weed/util/chunk_cache/chunk_cache.go
+++ b/weed/util/chunk_cache/chunk_cache.go
@@ -1,14 +1,18 @@
 package chunk_cache
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/storage/needle"
 )
 
+var ErrorOutOfBounds = errors.New("attempt to read out of bounds")
+
 type ChunkCache interface {
 	GetChunk(fileId string, minSize uint64) (data []byte)
+	GetChunkSlice(fileId string, offset, length uint64) []byte
 	SetChunk(fileId string, data []byte)
 }
 
@@ -21,6 +25,8 @@ type TieredChunkCache struct {
 	onDiskCacheSizeLimit1 uint64
 	onDiskCacheSizeLimit2 uint64
 }
+
+var _ ChunkCache = &TieredChunkCache{}
 
 func NewTieredChunkCache(maxEntries int64, dir string, diskSizeInUnit int64, unitSize int64) *TieredChunkCache {
 
@@ -87,6 +93,58 @@ func (c *TieredChunkCache) doGetChunk(fileId string, minSize uint64) (data []byt
 
 }
 
+func (c *TieredChunkCache) GetChunkSlice(fileId string, offset, length uint64) []byte {
+	if c == nil {
+		return nil
+	}
+
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.doGetChunkSlice(fileId, offset, length)
+}
+
+func (c *TieredChunkCache) doGetChunkSlice(fileId string, offset, length uint64) (data []byte) {
+
+	minSize := offset + length
+	if minSize <= c.onDiskCacheSizeLimit0 {
+		data, err := c.memCache.getChunkSlice(fileId, offset, length)
+		if err != nil {
+			glog.Errorf("failed to read from memcache: %s", err)
+		}
+		if len(data) >= int(minSize) {
+			return data
+		}
+	}
+
+	fid, err := needle.ParseFileIdFromString(fileId)
+	if err != nil {
+		glog.Errorf("failed to parse file id %s", fileId)
+		return nil
+	}
+
+	if minSize <= c.onDiskCacheSizeLimit0 {
+		data = c.diskCaches[0].getChunkSlice(fid.Key, offset, length)
+		if len(data) >= int(minSize) {
+			return data
+		}
+	}
+	if minSize <= c.onDiskCacheSizeLimit1 {
+		data = c.diskCaches[1].getChunkSlice(fid.Key, offset, length)
+		if len(data) >= int(minSize) {
+			return data
+		}
+	}
+	{
+		data = c.diskCaches[2].getChunkSlice(fid.Key, offset, length)
+		if len(data) >= int(minSize) {
+			return data
+		}
+	}
+
+	return nil
+}
+
 func (c *TieredChunkCache) SetChunk(fileId string, data []byte) {
 	if c == nil {
 		return
@@ -130,4 +188,11 @@ func (c *TieredChunkCache) Shutdown() {
 	for _, diskCache := range c.diskCaches {
 		diskCache.shutdown()
 	}
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
 }

--- a/weed/util/chunk_cache/chunk_cache_in_memory.go
+++ b/weed/util/chunk_cache/chunk_cache_in_memory.go
@@ -31,6 +31,20 @@ func (c *ChunkCacheInMemory) GetChunk(fileId string) []byte {
 	return data
 }
 
+func (c *ChunkCacheInMemory) getChunkSlice(fileId string, offset, length uint64) ([]byte, error) {
+	item := c.cache.Get(fileId)
+	if item == nil {
+		return nil, nil
+	}
+	data := item.Value().([]byte)
+	item.Extend(time.Hour)
+	wanted := min(int(length), len(data)-int(offset))
+	if wanted < 0 {
+		return nil, ErrorOutOfBounds
+	}
+	return data[offset : int(offset)+wanted], nil
+}
+
 func (c *ChunkCacheInMemory) SetChunk(fileId string, data []byte) {
 	localCopy := make([]byte, len(data))
 	copy(localCopy, data)

--- a/weed/util/chunk_cache/on_disk_cache_layer.go
+++ b/weed/util/chunk_cache/on_disk_cache_layer.go
@@ -82,6 +82,28 @@ func (c *OnDiskCacheLayer) getChunk(needleId types.NeedleId) (data []byte) {
 
 }
 
+func (c *OnDiskCacheLayer) getChunkSlice(needleId types.NeedleId, offset, length uint64) (data []byte) {
+
+	var err error
+
+	for _, diskCache := range c.diskCaches {
+		data, err = diskCache.getNeedleSlice(needleId, offset, length)
+		if err == storage.ErrorNotFound {
+			continue
+		}
+		if err != nil {
+			glog.Errorf("failed to read cache file %s id %d", diskCache.fileName, needleId)
+			continue
+		}
+		if len(data) != 0 {
+			return
+		}
+	}
+
+	return nil
+
+}
+
 func (c *OnDiskCacheLayer) shutdown() {
 
 	for _, diskCache := range c.diskCaches {


### PR DESCRIPTION
Very lightly tested, but for me this improved read time for a 1.4G file through FUSE from 4m to 9s. It looks like each FUSE read request winds up creating a new `ChunkReadAt`, which means that loading the entire chunk into memory is just thrashing GC, because it gets discarded after every read request.