### PR TITLE
fix concurrent vacuum & delete panic

### DIFF
--- a/weed/server/volume_grpc_vacuum.go
+++ b/weed/server/volume_grpc_vacuum.go
@@ -44,19 +44,14 @@ func (vs *VolumeServer) VacuumVolumeCommit(ctx context.Context, req *volume_serv
 
 	resp := &volume_server_pb.VacuumVolumeCommitResponse{}
 
-	err := vs.store.CommitCompactVolume(needle.VolumeId(req.VolumeId))
+	readOnly, err := vs.store.CommitCompactVolume(needle.VolumeId(req.VolumeId))
 
 	if err != nil {
 		glog.Errorf("commit volume %d: %v", req.VolumeId, err)
 	} else {
 		glog.V(1).Infof("commit volume %d", req.VolumeId)
 	}
-	if err == nil {
-		if vs.store.GetVolume(needle.VolumeId(req.VolumeId)).IsReadOnly() {
-			resp.IsReadOnly = true
-		}
-	}
-
+	resp.IsReadOnly = readOnly
 	return resp, err
 
 }

--- a/weed/storage/store_vacuum.go
+++ b/weed/storage/store_vacuum.go
@@ -25,11 +25,11 @@ func (s *Store) CompactVolume(vid needle.VolumeId, preallocate int64, compaction
 	}
 	return fmt.Errorf("volume id %d is not found during compact", vid)
 }
-func (s *Store) CommitCompactVolume(vid needle.VolumeId) error {
+func (s *Store) CommitCompactVolume(vid needle.VolumeId) (bool, error) {
 	if v := s.findVolume(vid); v != nil {
-		return v.CommitCompact()
+		return v.IsReadOnly(), v.CommitCompact()
 	}
-	return fmt.Errorf("volume id %d is not found during commit compact", vid)
+	return false, fmt.Errorf("volume id %d is not found during commit compact", vid)
 }
 func (s *Store) CommitCleanupVolume(vid needle.VolumeId) error {
 	if v := s.findVolume(vid); v != nil {


### PR DESCRIPTION
When delete volume during compact, something like this could happen:
1. `CommitCompactVolume` is done
2. `DeleteVolume` triggered right after commit, holds `volumesLock`
3. `GetVolume` RLock() waits for `volumesLock` Unlock(), after that it returns nil
4. `IsReadOnly` panic for nil pointer dereference