### PR TITLE
put-object and copy-object metadata patch

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -102,6 +102,18 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
+                // PATCH 
+                newEntry, newEntryErr := s3a.getEntry(s3a.option.BucketsPath, bucket+object)
+
+                if newEntryErr == nil {
+                   newEntry.Extended = weed_server.SaveAmzMetaData(r, newEntry.Extended, true)
+
+                   touchErr := s3a.touch(s3a.option.BucketsPath+"/"+bucket, object, newEntry)
+                   if touchErr != nil {
+                        glog.V(0).Infof("error: %v ", touchErr)
+                   }
+                }
+
 		setEtag(w, etag)
 	}
 

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -108,9 +108,11 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
                 if newEntryErr == nil {
                    newEntry.Extended = weed_server.SaveAmzMetaData(r, newEntry.Extended, true)
 
-                   touchErr := s3a.touch(s3a.option.BucketsPath+"/"+bucket, object, newEntry)
-                   if touchErr != nil {
-                        glog.V(0).Infof("error: %v ", touchErr)
+                   if len(newEntry.Extended) > 0 {
+                      touchErr := s3a.touch(s3a.option.BucketsPath+"/"+bucket, object, newEntry)
+                      if touchErr != nil {
+                         glog.V(0).Infof("error: %v ", touchErr)
+                      }
                    }
                 }
 


### PR DESCRIPTION
put-object / copy-object metadata seem work after adding touch().
But I am not sure this method is correct or not.