### PR TITLE
Return artificial . and .. directories

### DIFF
--- a/weed/filesys/wfs.go
+++ b/weed/filesys/wfs.go
@@ -3,9 +3,6 @@ package filesys
 import (
 	"context"
 	"fmt"
-	"github.com/chrislusf/seaweedfs/weed/filer"
-	"github.com/chrislusf/seaweedfs/weed/storage/types"
-	"github.com/chrislusf/seaweedfs/weed/wdclient"
 	"math"
 	"math/rand"
 	"os"
@@ -13,6 +10,10 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/chrislusf/seaweedfs/weed/filer"
+	"github.com/chrislusf/seaweedfs/weed/storage/types"
+	"github.com/chrislusf/seaweedfs/weed/wdclient"
 
 	"google.golang.org/grpc"
 
@@ -46,11 +47,12 @@ type Option struct {
 	DataCenter         string
 	Umask              os.FileMode
 
-	MountUid   uint32
-	MountGid   uint32
-	MountMode  os.FileMode
-	MountCtime time.Time
-	MountMtime time.Time
+	MountUid         uint32
+	MountGid         uint32
+	MountMode        os.FileMode
+	MountCtime       time.Time
+	MountMtime       time.Time
+	MountParentInode uint64
 
 	VolumeServerAccess string // how to access volume servers
 	Cipher             bool   // whether encrypt data on volume server

--- a/weed/filesys/xattr.go
+++ b/weed/filesys/xattr.go
@@ -113,6 +113,21 @@ func (wfs *WFS) maybeLoadEntry(dir, name string) (entry *filer_pb.Entry, err err
 	fullpath := util.NewFullPath(dir, name)
 	// glog.V(3).Infof("read entry cache miss %s", fullpath)
 
+	// return a valid entry for the mount root
+	if string(fullpath) == wfs.option.FilerMountRootPath {
+		return &filer_pb.Entry{
+			Name:        wfs.option.FilerMountRootPath,
+			IsDirectory: true,
+			Attributes: &filer_pb.FuseAttributes{
+				Mtime:    wfs.option.MountMtime.Unix(),
+				FileMode: uint32(wfs.option.MountMode),
+				Uid:      wfs.option.MountUid,
+				Gid:      wfs.option.MountGid,
+				Crtime:   wfs.option.MountCtime.Unix(),
+			},
+		}, nil
+	}
+
 	// read from async meta cache
 	meta_cache.EnsureVisited(wfs.metaCache, wfs, util.FullPath(dir))
 	cachedEntry, cacheErr := wfs.metaCache.FindEntry(context.Background(), fullpath)


### PR DESCRIPTION
this adds support for `.` and `..` directories in fuse mounts. they properly point to the correct inodes of directories of themselves (`.`) and to their parents (`..`), also for the mount root + parent.
this especially solves some errors on linux. on mac it works already out of the box as either macos or osxfuse apparently adds those directories automatically.
this is tested on macos and linux (debian). i don't know if it makes sense to test this on other platforms too. maybe windows/freebsd?
i am happy to hear your thoughts :)