### PR TITLE
Fix for presigned urls with sha256 hashes not actually being used for upload checking

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -73,6 +73,7 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 			_, s3ErrCode = s3a.iam.isReqAuthenticatedV2(r)
 		case authTypePresigned, authTypeSigned:
 			_, s3ErrCode = s3a.iam.reqSignatureV4Verify(r)
+			dataReader = r.Body
 		}
 		if s3ErrCode != s3err.ErrNone {
 			s3err.WriteErrorResponse(w, s3ErrCode, r)


### PR DESCRIPTION
This is a fix for the issue where sha256 hashes aren't compared against the uploaded file.  I don't know go and I have a feeling that reading the file multiple times (or even once if it's a massive file) could be a bit of an issue for performance and memory usage.  I would appreciate input because as it is I don't think this is general enough for other people's use cases.  All files to my servers will be limited in size so I won't have to worry about it.

https://github.com/chrislusf/seaweedfs/issues/2166

When a file is being uploaded via PUT or POST request with a presigned url and the body is not nil the file is read and then hashed to compare against the X-Amz-Content-Sha256 query parameter.