### PR TITLE
Cassandra: Use TokenAwareHostPolicy with fallback to localDC by default

### DIFF
--- a/weed/command/scaffold.go
+++ b/weed/command/scaffold.go
@@ -217,6 +217,8 @@ username=""
 password=""
 # This changes the data layout. Only add new directories. Removing/Updating will cause data loss.
 superLargeDirectories = []
+# Name of the datacenter local to this filer, used as host selection fallback.
+localDC=""
 
 [hbase]
 enabled = false


### PR DESCRIPTION
See https://pkg.go.dev/github.com/gocql/gocql#hdr-Data_center_awareness_and_query_routing

This changes the default hostselectionpolicy (previously unset, defaults to RR): https://github.com/gocql/gocql/blob/master/cluster.go#L19 (strange since the java driver defaults to token-aware: https://docs.datastax.com/en/developer/java-driver/4.2/manual/core/load_balancing/#token-aware)

This adds a new localDC config option and if it's set, it will fallback to dc-aware RR instead of across the whole cluster.