### PR TITLE
Add the additional meta log

### DIFF
--- a/unmaintained/see_meta/see_meta.go
+++ b/unmaintained/see_meta/see_meta.go
@@ -60,7 +60,7 @@ func walkMetaFile(dst *os.File) error {
 
 		fmt.Fprintf(os.Stdout, "file %s %v\n", util.FullPath(fullEntry.Dir).Child(fullEntry.Entry.Name), fullEntry.Entry.Attributes.String())
 		for i, chunk := range fullEntry.Entry.Chunks {
-			fmt.Fprintf(os.Stdout, "  chunk %d %v\n", i+1, chunk.String())
+			fmt.Fprintf(os.Stdout, "  chunk: %d %v %d,%x%08x\n", i+1, chunk, chunk.Fid.VolumeId, chunk.Fid.FileKey, chunk.Fid.Cookie)
 		}
 
 	}


### PR DESCRIPTION
Additional logs are output to match the `volume.fsck -findMissingChunksInFiler` command result.