### PR TITLE
Change default permissions

### DIFF
--- a/weed/filer/filer.go
+++ b/weed/filer/filer.go
@@ -207,7 +207,7 @@ func (f *Filer) ensureParentDirecotryEntry(ctx context.Context, entry *Entry, di
 			Attr: Attr{
 				Mtime:       now,
 				Crtime:      now,
-				Mode:        os.ModeDir | entry.Mode | 0110,
+				Mode:        os.ModeDir | entry.Mode | 0111,
 				Uid:         entry.Uid,
 				Gid:         entry.Gid,
 				Collection:  entry.Collection,


### PR DESCRIPTION
Changed default permissions for directory creation. In the existing `0110`, there is no way to read the directory for other users until the file is given read and execute permissions. If it is not an executable file such as an image, it is generally thought that 644 permission is correct.

I think we need to add the umask option to the filer.