### PR TITLE
chore(ci): move to using newer metadata action

### DIFF
--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -15,7 +15,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3
         with:
           images: |
             chrislusf/seaweedfs
@@ -68,7 +68,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3
         with:
           images: |
             chrislusf/seaweedfs

--- a/.github/workflows/container_release.yml
+++ b/.github/workflows/container_release.yml
@@ -15,7 +15,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3
         with:
           images: |
             chrislusf/seaweedfs
@@ -70,7 +70,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3
         with:
           images: |
             chrislusf/seaweedfs

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -14,7 +14,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3
         with:
           images: |
             chrislusf/seaweedfs


### PR DESCRIPTION
The `crazy-max/ghaction-docker-meta@v2` action was moved to `docker/metadata-action@v3`. Seems to be fully backwards-compatible.