### PR TITLE
feature(cross-platform): add multi-arch support to release

### DIFF
--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -13,23 +13,15 @@ jobs:
     strategy:
       matrix:
         goos: [linux, windows, darwin, freebsd, netbsd, openbsd]
-        goarch: [amd64, arm, arm64, 386, ppc64le, s390x]
+        goarch: [amd64, arm, arm64, 386]
         exclude:
           - goarch: arm
             goos: darwin
           - goarch: 386
             goos: darwin
-          - goarch: ppc64le
-            goos: darwin
-          - goarch: s390x
-            goos: darwin
           - goarch: arm
             goos: windows
           - goarch: arm64
-            goos: windows
-          - goarch: ppc64le
-            goos: windows
-          - goarch: s390x
             goos: windows
 
     concurrency:

--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
   workflow_dispatch: []
 
-concurrency:
-  group: ${{ github.head_ref }}/binary_test
-  cancel-in-progress: true
-
 jobs:
 
   build:
@@ -35,6 +31,10 @@ jobs:
             goos: windows
           - goarch: s390x
             goos: windows
+
+    concurrency:
+      group: ${{ github.head_ref }}/binary_test/${{ matrix.goos }}/${{ matrix.goarch }}
+      cancel-in-progress: true
 
     steps:
 

--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: []
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref }}/binary_test
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -49,4 +49,3 @@ jobs:
 
       - name: Build
         run: cd weed; GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -v .
-        continue-on-error: true

--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -57,3 +57,4 @@ jobs:
 
       - name: Build
         run: cd weed; GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -v .
+        continue-on-error: true

--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -38,13 +38,22 @@ jobs:
 
     steps:
 
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Go cross-platform build test
-        uses: thatisuday/go-cross-build@v1
-        with:
-          platforms: ${{ matrix.goos }}/${{ matrix.goarch }}
-          package: 'weed'
-          name: 'weed'
-          dest: '/tmp/dist'
+      - name: Get dependencies
+        run: |
+          cd weed; go get -v -t -d ./...
+          if [ -f Gopkg.toml ]; then
+              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+              dep ensure
+          fi
+
+      - name: Build
+        run: cd weed; GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -v .

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -55,7 +55,7 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
@@ -109,6 +109,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -55,7 +55,7 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
@@ -109,6 +109,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   build-latest:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        platform: [ linux ]
+        arch: [ amd64, arm, arm64, 386 ]
+
     steps:
       -
         name: Checkout
@@ -55,12 +60,17 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: ${{ matrix.platform }}/${{ matrix.arch }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
   build-dev:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        platform: [ linux ]
+        arch: [ amd64, arm, arm64, 386 ]
+
     steps:
       -
         name: Checkout
@@ -109,6 +119,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: ${{ matrix.platform }}/${{ matrix.arch }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -55,7 +55,7 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
@@ -109,6 +109,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_release.yml
+++ b/.github/workflows/container_release.yml
@@ -1,4 +1,5 @@
 name: Build Release Containers
+
 on:
   push:
     tags:

--- a/.github/workflows/container_release.yml
+++ b/.github/workflows/container_release.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build-default:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        platform: [ linux ]
+        arch: [ amd64, arm, arm64, 386 ]
+
     steps:
       -
         name: Checkout
@@ -59,11 +64,16 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: ${{ matrix.platform }}/${{ matrix.arch }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
   build-large:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        platform: [ linux ]
+        arch: [ amd64, arm, arm64, 386 ]
+
     steps:
       -
         name: Checkout
@@ -114,6 +124,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build_large
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: ${{ matrix.platform }}/${{ matrix.arch }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_release.yml
+++ b/.github/workflows/container_release.yml
@@ -58,7 +58,7 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
   build-large:
@@ -113,6 +113,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build_large
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_release.yml
+++ b/.github/workflows/container_release.yml
@@ -59,7 +59,7 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
   build-large:
@@ -114,6 +114,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build_large
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_release.yml
+++ b/.github/workflows/container_release.yml
@@ -58,7 +58,7 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
   build-large:
@@ -113,6 +113,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build_large
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -39,6 +39,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -12,6 +12,11 @@ concurrency:
 jobs:
   build-test:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        platform: [ linux ]
+        arch: [ amd64, arm, arm64, 386 ]
+
     steps:
       -
         name: Checkout
@@ -44,6 +49,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: ${{ matrix.platform }}/${{ matrix.arch }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -39,6 +39,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -1,4 +1,5 @@
 name: Test Building Container Images
+
 on:
   push:
   pull_request:

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: []
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref }}/container_test
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch: []
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -44,6 +44,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref }}/go
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows, darwin, freebsd, netbsd, openbsd ]
-        goarch: [amd64, arm, arm64, 386]
+        goos: [linux, windows, darwin, freebsd, netbsd, openbsd]
+        goarch: [amd64, arm, arm64, 386, ppc64le, s390x]
         exclude:
           - goarch: arm
             goos: darwin
           - goarch: 386
             goos: darwin
+          - goarch: ppc64le
+            goos: darwin
+          - goarch: s390x
+            goos: darwin
+          - goarch: arm
+            goos: windows
           - goarch: arm64
             goos: windows
-          - goarch: arm
+          - goarch: ppc64le
+            goos: windows
+          - goarch: s390x
             goos: windows
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,23 +12,15 @@ jobs:
     strategy:
       matrix:
         goos: [linux, windows, darwin, freebsd, netbsd, openbsd]
-        goarch: [amd64, arm, arm64, 386, ppc64le, s390x]
+        goarch: [amd64, arm, arm64, 386]
         exclude:
           - goarch: arm
             goos: darwin
           - goarch: 386
             goos: darwin
-          - goarch: ppc64le
-            goos: darwin
-          - goarch: s390x
-            goos: darwin
           - goarch: arm
             goos: windows
           - goarch: arm64
-            goos: windows
-          - goarch: ppc64le
-            goos: windows
-          - goarch: s390x
             goos: windows
 
     steps:

--- a/.github/workflows/release_binaries.yml
+++ b/.github/workflows/release_binaries.yml
@@ -15,12 +15,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows, darwin, freebsd ]
-        goarch: [amd64, arm]
+        goos: [linux, windows, darwin, freebsd, netbsd, openbsd]
+        goarch: [amd64, arm, arm64, 386, ppc64le, s390x]
         exclude:
           - goarch: arm
             goos: darwin
+          - goarch: 386
+            goos: darwin
+          - goarch: ppc64le
+            goos: darwin
+          - goarch: s390x
+            goos: darwin
           - goarch: arm
+            goos: windows
+          - goarch: arm64
+            goos: windows
+          - goarch: ppc64le
+            goos: windows
+          - goarch: s390x
             goos: windows
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/release_binaries.yml
+++ b/.github/workflows/release_binaries.yml
@@ -16,23 +16,15 @@ jobs:
     strategy:
       matrix:
         goos: [linux, windows, darwin, freebsd, netbsd, openbsd]
-        goarch: [amd64, arm, arm64, 386, ppc64le, s390x]
+        goarch: [amd64, arm, arm64, 386]
         exclude:
           - goarch: arm
             goos: darwin
           - goarch: 386
             goos: darwin
-          - goarch: ppc64le
-            goos: darwin
-          - goarch: s390x
-            goos: darwin
           - goarch: arm
             goos: windows
           - goarch: arm64
-            goos: windows
-          - goarch: ppc64le
-            goos: windows
-          - goarch: s390x
             goos: windows
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -1,4 +1,4 @@
-name: Build Dev Binaries
+name: Cross-platform binary build test
 
 on:
   push:

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -1,0 +1,46 @@
+name: Build Dev Binaries
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch: []
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin, freebsd, netbsd, openbsd]
+        goarch: [amd64, arm, arm64, 386, ppc64le, s390x]
+        exclude:
+          - goarch: arm
+            goos: darwin
+          - goarch: 386
+            goos: darwin
+          - goarch: ppc64le
+            goos: darwin
+          - goarch: s390x
+            goos: darwin
+          - goarch: arm
+            goos: windows
+          - goarch: arm64
+            goos: windows
+          - goarch: ppc64le
+            goos: windows
+          - goarch: s390x
+            goos: windows
+
+    steps:
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Go cross-platform build test
+        uses: thatisuday/go-cross-build@v1
+        with:
+          platforms: ${{ matrix.goos }}/${{ matrix.goarch }}
+          package: 'weed'
+          name: 'weed'
+          dest: '/tmp/dist'

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch: []
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,9 @@ RUN \
          elif [ $(uname -m) == "x86_64" ] && [ $(getconf LONG_BIT) == "32" ]; then echo "386"; \
          elif [ $(uname -m) == "aarch64" ]; then echo "arm64"; \
          elif [ $(uname -m) == "armv7l" ]; then echo "arm"; \
-         elif [ $(uname -m) == "armv6l" ]; then echo "arm"; fi;) && \
+         elif [ $(uname -m) == "armv6l" ]; then echo "arm"; \
+         elif [ $(uname -m) == "s390x" ]; then echo "s390x"; \
+         elif [ $(uname -m) == "ppc64le" ]; then echo "ppc64le"; fi;) && \
     echo "Building for $ARCH" 1>&2 && \
     SUPERCRONIC_SHA1SUM=$(echo $ARCH | sed 's/386/e0126b0102b9f388ecd55714358e3ad60d0cebdb/g' | sed 's/amd64/5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85/g' | sed 's/arm64/e2714c43e7781bf1579c85aa61259245f56dbba1/g' | sed 's/arm/47481c3341bc3a1ae91a728e0cc63c8e6d3791ad/g') && \
     SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-$ARCH && \


### PR DESCRIPTION
Currently, it looks like there aren't any builds for PPC or Z-kernel platforms. The project is also missing multiple arches from the release system.

Below are the missing platforms added as part of this PR:
- `arm64`
- `386`

Below are the missing platforms not added to this PR due to compatibility issues ([see here](https://github.com/chrislusf/seaweedfs/pull/2288/checks?sha=46e78e9b3ef7b3a48553411ff56ef2dcf54ea5b3)):
- `ppc64le`
- `s390x`

This MR allows the team to support future architectures with minimal work if/when they decide to.

Supported Go and Buildx architectures confirmed against:

- https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63#a-list-of-valid-goarch-values
- https://github.com/logband/github-buildx-stats/runs/3448399619?check_suite_focus=true

Changes:
- Added a new cross-platform binary test build to cover that if there are any issues in the future.
- Added the new architectures to the release workflow.
- Added the new architectures into the Dockerfile so they are supported once a new release is built. This includes architectures with compatibility issues, since they may be added in the future.
- The container builds (test / latest / release) use matrixes.

This should make development a lot easier for newcomers to the project! 🎉