### PR TITLE
mount: fix consistency issue, invalidate mount meta cache more aggressively

### DIFF
--- a/weed/filesys/meta_cache/meta_cache_subscribe.go
+++ b/weed/filesys/meta_cache/meta_cache_subscribe.go
@@ -39,14 +39,10 @@ func SubscribeMetaEvents(mc *MetaCache, selfSignature int32, client filer_pb.Fil
 		err := mc.AtomicUpdateEntryFromFiler(context.Background(), oldPath, newEntry)
 		if err == nil {
 			if message.OldEntry != nil && message.NewEntry != nil {
-				if message.OldEntry.Name == message.NewEntry.Name {
-					// no need to invalidate
-				} else {
-					oldKey := util.NewFullPath(resp.Directory, message.OldEntry.Name)
-					mc.invalidateFunc(oldKey)
-					newKey := util.NewFullPath(dir, message.NewEntry.Name)
-					mc.invalidateFunc(newKey)
-				}
+				oldKey := util.NewFullPath(resp.Directory, message.OldEntry.Name)
+				mc.invalidateFunc(oldKey)
+				newKey := util.NewFullPath(dir, message.NewEntry.Name)
+				mc.invalidateFunc(newKey)
 			} else if message.OldEntry == nil && message.NewEntry != nil {
 				// no need to invaalidate
 			} else if message.OldEntry != nil && message.NewEntry == nil {


### PR DESCRIPTION
I upgraded weed mount from 2.49 and it seems there's a consistency problem. Picture's worth a thousand words: this is `weed server`  with 2 mounts on 2 servers. I ran these commands roughly alternating between these two servers. You can see that the `hi` file seems to be getting clobbered, as if the file length metadata wasn't updating:
![image](https://user-images.githubusercontent.com/4633048/131216734-2ffcade0-6afe-4235-ae7f-9140fcb9fdfd.png)
![image](https://user-images.githubusercontent.com/4633048/131216737-cd337b4a-d2ac-4bed-b2c4-1de98fadf40a.png)

With my change it now alternates as expected:
![image](https://user-images.githubusercontent.com/4633048/131216815-0401a8ba-3013-412b-9953-6629bb0dc6d1.png)
![image](https://user-images.githubusercontent.com/4633048/131216813-058015a6-434e-4d4b-8725-1d1a31470e9f.png)

I'm not totally sure why this works, just looked through the commits and this one looked suspicious:  https://github.com/nivekuil/seaweedfs/commit/e6ba2f9c372f8f160003dac63d51b6dde0a512de