### PR TITLE
fix(ci): update latest to only run once

### DIFF
--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -1,11 +1,6 @@
 name: Cross-platform binary build test
 
 on:
-  push:
-    branches-ignore:
-      - master
-    tags-ignore:
-      - *
   pull_request:
   workflow_dispatch: []
 

--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -2,6 +2,10 @@ name: Cross-platform binary build test
 
 on:
   push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - *
   pull_request:
   workflow_dispatch: []
 

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -8,10 +8,6 @@ on:
 jobs:
   build-latest:
     runs-on: [ubuntu-latest]
-    strategy:
-      matrix:
-        platform: [ linux ]
-        arch: [ amd64, arm, arm64, 386 ]
 
     steps:
       -
@@ -60,16 +56,12 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
-          platforms: ${{ matrix.platform }}/${{ matrix.arch }}
+          platforms: linux/amd64, linux/arm, linux/arm64, linux/386
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
   build-dev:
     runs-on: [ubuntu-latest]
-    strategy:
-      matrix:
-        platform: [ linux ]
-        arch: [ amd64, arm, arm64, 386 ]
 
     steps:
       -
@@ -119,6 +111,6 @@ jobs:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile.go_build
-          platforms: ${{ matrix.platform }}/${{ matrix.arch }}
+          platforms: linux/amd64, linux/arm, linux/arm64, linux/386
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -2,6 +2,10 @@ name: Test Building Container Images
 
 on:
   push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - *
   pull_request:
   workflow_dispatch: []
 

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -1,11 +1,6 @@
 name: Test Building Container Images
 
 on:
-  push:
-    branches-ignore:
-      - master
-    tags-ignore:
-      - *
   pull_request:
   workflow_dispatch: []
 

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./docker
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
           file: ./docker/Dockerfile
           platforms: ${{ matrix.platform }}/${{ matrix.arch }}
           tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
Further update from #2291, apply the same logic to `latest` images.

Also includes:
- a quick fix to never push to Docker Hub from pull requests on test jobs
- a quick fix to never run the test jobs on anything other than `pull_request`

Test is fine to stay as-is since it's not pushing.