### PR TITLE
fix(ci): use cleaner naming for jobs

### DIFF
--- a/.github/workflows/binary_test.yml
+++ b/.github/workflows/binary_test.yml
@@ -1,4 +1,4 @@
-name: Cross-platform binary build test
+name: "go: test building cross-platform binary"
 
 on:
   push:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,4 +1,4 @@
-name: Cleanup
+name: "chore: cleanup"
 
 on:
   push:

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -1,4 +1,5 @@
-name: Build Latest Containers
+name: "docker: build latest containers"
+
 on:
   push:
     branches:

--- a/.github/workflows/container_release.yml
+++ b/.github/workflows/container_release.yml
@@ -1,4 +1,4 @@
-name: Build Release Containers
+name: "docker: build release containers"
 
 on:
   push:

--- a/.github/workflows/container_test.yml
+++ b/.github/workflows/container_test.yml
@@ -1,4 +1,4 @@
-name: Test Building Container Images
+name: "docker: test building container images"
 
 on:
   push:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: "go: test building binary"
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build Dev Binaries
+name: "go: build dev binaries"
 
 on:
   push:

--- a/.github/workflows/release_binaries.yml
+++ b/.github/workflows/release_binaries.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build Versioned Releases
+name: "go: build versioned binaries"
 
 on:
   release:


### PR DESCRIPTION
Not sure if you want to do this since it'll clutter the Actions page (it can't seem to recognise job name changes).
What we can do is remove old runs, as described in: https://github.community/t/delete-old-workflow-results/16152/42

I'm happy to add this to the cleanup job in another PR if you wish.

Feel free to reject if you prefer the current naming!