### PR TITLE
Detect ipv6 addresses

### DIFF
--- a/weed/util/network.go
+++ b/weed/util/network.go
@@ -24,7 +24,7 @@ func DetectedHostAddress() string {
 
 		for _, a := range addrs {
 			if ipNet, ok := a.(*net.IPNet); ok && !ipNet.IP.IsLoopback() {
-				if ipNet.IP.To4() != nil {
+				if ipNet.IP.To4() != nil || ipNet.IP.To16() != nil {
 					return ipNet.IP.String()
 				}
 			}


### PR DESCRIPTION
This allows ipv6 addresses to be found for e.g. volume server IP.  Note that this may be a breaking change if the ipv6 came first in whatever order this is traversed. I think most setups would have the routable interfaces earlier in the iterator order, and any ipv6s are more likely to be routable than ipv4. It also might make sense to have additional checks for interface local/link local as documented here https://pkg.go.dev/net#IP.IsInterfaceLocalMulticast, though this patch at least works for me (pod has a routable ipv6 + a private, node-local ipv4)