### PR TITLE
add bloom filter to leveldb_store to improve fuse performance.

### DIFF
--- a/weed/filer/leveldb/leveldb_store.go
+++ b/weed/filer/leveldb/leveldb_store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/syndtr/goleveldb/leveldb"
 	leveldb_errors "github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	leveldb_util "github.com/syndtr/goleveldb/leveldb/util"
 	"os"
@@ -48,6 +49,7 @@ func (store *LevelDBStore) initialize(dir string) (err error) {
 		BlockCacheCapacity:            32 * 1024 * 1024, // default value is 8MiB
 		WriteBuffer:                   16 * 1024 * 1024, // default value is 4MiB
 		CompactionTableSizeMultiplier: 10,
+		Filter:                        filter.NewBloomFilter(8), // false positive rate 0.02
 	}
 
 	if store.db, err = leveldb.OpenFile(dir, opts); err != nil {


### PR DESCRIPTION
when use `weed mount ` to upload small files to directory which has millions of files.

bloom improve performance obviously from 3 Mbps to 30 Mbps.


perf data after add bloom filter:

```
-   98.37%     0.00%  weed     weed                [.] runtime.goexit                                                                                                    ▒
   - runtime.goexit                                                                                                                                                      ▒
      - 59.82% github.com/seaweedfs/fuse/fs.(*Server).Serve.func2                                                                                                        ▒
         - 59.80% github.com/seaweedfs/fuse/fs.(*Server).Serve.func1                                                                                                     ▒
            - 56.74% github.com/seaweedfs/fuse/fs.(*Server).serve                                                                                                        ▒
               - 53.98% github.com/seaweedfs/fuse/fs.(*Server).handleRequest                                                                                             ▒
                  - 42.99% github.com/chrislusf/seaweedfs/weed/filesys.(*Dir).Lookup                                                                                     ▒
                     - 42.63% github.com/chrislusf/seaweedfs/weed/filesys/meta_cache.(*MetaCache).FindEntry                                                              ▒
                        - 42.61% github.com/chrislusf/seaweedfs/weed/filer.(*FilerStoreWrapper).FindEntry                                                                ▒
                           - 42.28% github.com/chrislusf/seaweedfs/weed/filer/leveldb.(*LevelDBStore).FindEntry                                                          ▒
                              - 42.17% github.com/syndtr/goleveldb/leveldb.(*DB).Get                                                                                     ▒
                                 - 42.10% github.com/syndtr/goleveldb/leveldb.(*DB).get                                                                                  ▒
                                    - 40.94% github.com/syndtr/goleveldb/leveldb.(*version).get                                                                          ▒
                                       - 40.92% github.com/syndtr/goleveldb/leveldb.(*version).walkOverlapping                                                           ▒
                                          - 40.75% github.com/syndtr/goleveldb/leveldb.(*version).get.func1                                                              ▒
                                             - 40.71% github.com/syndtr/goleveldb/leveldb.(*tOps).find                                                                   ▒
                                                - 40.58% github.com/syndtr/goleveldb/leveldb/table.(*Reader).find                                                        ▒
                                                   + 30.85% github.com/syndtr/goleveldb/leveldb/table.(*Reader).getIndexBlock                                            ▒
                                                   + 9.09% github.com/syndtr/goleveldb/leveldb/table.(*Reader).getFilterBlock                                            ▒
                                    + 1.08% github.com/syndtr/goleveldb/leveldb.memGet                                                                                   ▒
                  + 5.08% github.com/chrislusf/seaweedfs/weed/filesys.(*FileHandle).Flush                                                                                ▒
                  + 2.41% github.com/seaweedfs/fuse/fs.nodeAttr                                                                                                          ▒
                  + 1.16% github.com/chrislusf/seaweedfs/weed/filesys.(*FileHandle).Write                                                                                ▒
               + 1.12% github.com/seaweedfs/fuse.(*Header).RespondError                                                                                                  ▒
               + 0.70% context.WithCancel                                                                                                                                ▒
                 0.51% github.com/seaweedfs/fuse/fs.(*Server).serve.func1                                                                                                ▒
            + 2.96% runtime.chanrecv2                                                                                                                                    ▒
      + 14.00% runtime.systemstack                                                                                                                                       ▒
      + 12.12% github.com/chrislusf/seaweedfs/weed/util.(*LimitedConcurrentExecutor).Execute.func1                                                                       ▒
      + 3.31% google.golang.org/grpc/internal/transport.newHTTP2Client.func3                                                                                             ▒
      + 2.90% runtime.main                                                                                                                                               ▒
      + 2.26% google.golang.org/grpc/internal/transport.(*http2Client).reader                                                                                            ▒
      + 1.34% net/http.(*persistConn).writeLoop                                                                                                                          ▒
        1.07% net/http.(*persistConn).readLoop                                                                                                                           ▒
      + 0.54% runtime.bgsweep                                                                                                                                            ▒

```