### PR TITLE
CompactionTableSizeMultiplier of leveldb use default value.  #2325

### DIFF
--- a/weed/filer/leveldb/leveldb_store.go
+++ b/weed/filer/leveldb/leveldb_store.go
@@ -46,10 +46,9 @@ func (store *LevelDBStore) initialize(dir string) (err error) {
 	}
 
 	opts := &opt.Options{
-		BlockCacheCapacity:            32 * 1024 * 1024, // default value is 8MiB
-		WriteBuffer:                   16 * 1024 * 1024, // default value is 4MiB
-		CompactionTableSizeMultiplier: 10,
-		Filter:                        filter.NewBloomFilter(8), // false positive rate 0.02
+		BlockCacheCapacity: 32 * 1024 * 1024,         // default value is 8MiB
+		WriteBuffer:        16 * 1024 * 1024,         // default value is 4MiB
+		Filter:             filter.NewBloomFilter(8), // false positive rate 0.02
 	}
 
 	if store.db, err = leveldb.OpenFile(dir, opts); err != nil {

--- a/weed/filer/leveldb2/leveldb2_store.go
+++ b/weed/filer/leveldb2/leveldb2_store.go
@@ -46,10 +46,9 @@ func (store *LevelDB2Store) initialize(dir string, dbCount int) (err error) {
 	}
 
 	opts := &opt.Options{
-		BlockCacheCapacity:            32 * 1024 * 1024, // default value is 8MiB
-		WriteBuffer:                   16 * 1024 * 1024, // default value is 4MiB
-		CompactionTableSizeMultiplier: 4,
-		Filter:                        filter.NewBloomFilter(8), // false positive rate 0.02
+		BlockCacheCapacity: 32 * 1024 * 1024,         // default value is 8MiB
+		WriteBuffer:        16 * 1024 * 1024,         // default value is 4MiB
+		Filter:             filter.NewBloomFilter(8), // false positive rate 0.02
 	}
 
 	for d := 0; d < dbCount; d++ {

--- a/weed/filer/leveldb3/leveldb3_store.go
+++ b/weed/filer/leveldb3/leveldb3_store.go
@@ -66,17 +66,15 @@ func (store *LevelDB3Store) initialize(dir string) (err error) {
 func (store *LevelDB3Store) loadDB(name string) (*leveldb.DB, error) {
 	bloom := filter.NewBloomFilter(8) // false positive rate 0.02
 	opts := &opt.Options{
-		BlockCacheCapacity:            32 * 1024 * 1024, // default value is 8MiB
-		WriteBuffer:                   16 * 1024 * 1024, // default value is 4MiB
-		CompactionTableSizeMultiplier: 4,
-		Filter:                        bloom,
+		BlockCacheCapacity: 32 * 1024 * 1024, // default value is 8MiB
+		WriteBuffer:        16 * 1024 * 1024, // default value is 4MiB
+		Filter:             bloom,
 	}
 	if name != DEFAULT {
 		opts = &opt.Options{
-			BlockCacheCapacity:            4 * 1024 * 1024, // default value is 8MiB
-			WriteBuffer:                   2 * 1024 * 1024, // default value is 4MiB
-			CompactionTableSizeMultiplier: 4,
-			Filter:                        bloom,
+			BlockCacheCapacity: 4 * 1024 * 1024, // default value is 8MiB
+			WriteBuffer:        2 * 1024 * 1024, // default value is 4MiB
+			Filter:             bloom,
 		}
 	}
 


### PR DESCRIPTION
To improve performance of leveldb find key in condition of large directory(millions of files) which use uuid as filename.

#2325