### PR TITLE
Fixed unwanted behavior of the SeaweedFS helm chart

### DIFF
--- a/k8s/helm_charts2/templates/filer-servicemonitor.yaml
+++ b/k8s/helm_charts2/templates/filer-servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.filer.metricsPort }}
+{{- if .Values.global.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -15,4 +16,5 @@ spec:
   selector:
     app: {{ template "seaweedfs.name" . }}
     component: filer
+{{- end }}
 {{- end }}

--- a/k8s/helm_charts2/templates/ingress.yaml
+++ b/k8s/helm_charts2/templates/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
  name: ingress-{{ template "seaweedfs.name" . }}-filer
+ namespace: {{ .Release.Namespace }}
  annotations:
    kubernetes.io/ingress.class: "nginx"
    nginx.ingress.kubernetes.io/auth-type: "basic"
@@ -32,6 +33,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: ingress-{{ template "seaweedfs.name" . }}-master
+  namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/auth-type: "basic"

--- a/k8s/helm_charts2/templates/s3-servicemonitor.yaml
+++ b/k8s/helm_charts2/templates/s3-servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.s3.metricsPort }}
+{{- if .Values.global.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -15,4 +16,5 @@ spec:
   selector:
     app: {{ template "seaweedfs.name" . }}
     component: s3
+{{- end }}
 {{- end }}

--- a/k8s/helm_charts2/templates/volume-servicemonitor.yaml
+++ b/k8s/helm_charts2/templates/volume-servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.volume.metricsPort }}
+{{- if .Values.global.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -15,4 +16,5 @@ spec:
   selector:
     app: {{ template "seaweedfs.name" . }}
     component: volume
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This PR adds the following features to fix some unwanted behavior:

- The ServiceMonitor resources doesn't get created when `global.monitoring.enabled` isn't set or set to false.
Before users had to install Prometheus even when monitoring was disabled.

- The Ingress resources now get deployed to the right namespace
Before the Ingress resource got deployed to the default namespace.