### PR TITLE
Fix: potencial iam identities data race

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/glog"
@@ -23,6 +24,8 @@ type Iam interface {
 }
 
 type IdentityAccessManagement struct {
+	m sync.Mutex
+
 	identities []*Identity
 	domain     string
 }
@@ -131,9 +134,12 @@ func (iam *IdentityAccessManagement) loadS3ApiConfiguration(config *iam_pb.S3Api
 		}
 		identities = append(identities, t)
 	}
-
+	iam.m.Lock()
+	
 	// atomically switch
 	iam.identities = identities
+
+	iam.m.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Hello! 
I guess I found a potential data race condition with `iam.identities`.
Method `loadS3ApiConfiguration` contains assignment to identities slice which is not safe. Cause it might be read in the same time by other goroutines (server handlers etc). This PR must fix this issue.