### PR TITLE
MongodbStore.ListDirectoryEntries panics on Find method failure

### DIFF
--- a/weed/filer/mongodb/mongodb_store.go
+++ b/weed/filer/mongodb/mongodb_store.go
@@ -193,6 +193,10 @@ func (store *MongodbStore) ListDirectoryEntries(ctx context.Context, dirPath uti
 	optLimit := int64(limit)
 	opts := &options.FindOptions{Limit: &optLimit, Sort: bson.M{"name": 1}}
 	cur, err := store.connect.Database(store.database).Collection(store.collectionName).Find(ctx, where, opts)
+	if err != nil {
+		return lastFileName, fmt.Errorf("failed to list directory entries: find error: %w", err)
+	}
+
 	for cur.Next(ctx) {
 		var data Model
 		err := cur.Decode(&data)


### PR DESCRIPTION
Hello!
I made a fix for nil pointer deference panic in *MongodbStore.ListDirectoryEntries method.
When *mongo.Collection.Find returns an error, *mongo.Cursor, which this method also returns, might be nil.

log:
```
Dec 02 12:59:11 mon001 weed[9050]: panic: runtime error: invalid memory address or nil pointer dereference
Dec 02 12:59:11 mon001 weed[9050]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x13f6922]  
Dec 02 12:59:11 mon001 weed[9050]: goroutine 2054744 [running]:  
Dec 02 12:59:11 mon001 weed[9050]: go.mongodb.org/mongo-driver/mongo.(*Cursor).next(0xc0099cfa40, {0x28327c0, 0xc009af8f30}, 0xc0)
Dec 02 12:59:11 mon001 weed[9050]:         /go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.0/mongo/cursor.go:102 +0x22
Dec 02 12:59:11 mon001 weed[9050]: go.mongodb.org/mongo-driver/mongo.(*Cursor).Next(...)
Dec 02 12:59:11 mon001 weed[9050]:         /go/pkg/mod/go.mongodb.org/mongo-driver@v1.7.0/mongo/cursor.go:81
Dec 02 12:59:11 mon001 weed[9050]: github.com/chrislusf/seaweedfs/weed/filer/mongodb.(*MongodbStore).ListDirectoryEntries(0xc0007f5b90, {0x28327c0, 0xc009af8f30}, {0xc010e20870, 0x0}, {0xc009d497d0, 0x17}, 0x0, 0x400, 0xc009af9230)
```

  