### PR TITLE
BUGFIX: add access.ui setting to scaffolded security.toml

### DIFF
--- a/weed/command/scaffold/security.toml
+++ b/weed/command/scaffold/security.toml
@@ -10,6 +10,13 @@
 key = ""
 expires_after_seconds = 10           # seconds
 
+# by default, if the signing key above is set, the Volume UI over HTTP is disabled.
+# by setting ui.access to true, you can re-enable the Volume UI. Despite
+# some information leakage (as the UI is unauthenticted), this should not
+# pose a security risk.
+[access]
+ui = false
+
 # jwt for read is only supported with master+volume setup. Filer does not support this mode.
 [jwt.signing.read]
 key = ""


### PR DESCRIPTION
... The property is read here: https://github.com/chrislusf/seaweedfs/blob/b70cb3e0b2a75543f0410d4c09f42aa95fcf2ee2/weed/server/volume_server.go#L69 but it was missing from documentation.

If this pull request is accepted, I'll also update the Wiki accordingly :)