### PR TITLE
redis2 filer store: use lua script for atomicity

### DIFF
--- a/weed/filer/redis2/redis_cluster_store.go
+++ b/weed/filer/redis2/redis_cluster_store.go
@@ -1,6 +1,7 @@
 package redis2
 
 import (
+	"context"
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/util"
 	"github.com/go-redis/redis/v8"
@@ -40,5 +41,6 @@ func (store *RedisCluster2Store) initialize(addresses []string, password string,
 		RouteByLatency: routeByLatency,
 	})
 	store.loadSuperLargeDirectories(superLargeDirectories)
+	store.detectSupportLuaScript(context.Background())
 	return
 }

--- a/weed/filer/redis2/redis_sentinel_store.go
+++ b/weed/filer/redis2/redis_sentinel_store.go
@@ -1,6 +1,7 @@
 package redis2
 
 import (
+	"context"
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/util"
 	"github.com/go-redis/redis/v8"
@@ -41,5 +42,6 @@ func (store *Redis2SentinelStore) initialize(addresses []string, masterName stri
 		ReadTimeout:     time.Second * 30,
 		WriteTimeout:    time.Second * 5,
 	})
+	store.detectSupportLuaScript(context.Background())
 	return
 }

--- a/weed/filer/redis2/redis_store.go
+++ b/weed/filer/redis2/redis_store.go
@@ -1,6 +1,7 @@
 package redis2
 
 import (
+	"context"
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/util"
 	"github.com/go-redis/redis/v8"
@@ -34,5 +35,6 @@ func (store *Redis2Store) initialize(hostPort string, password string, database 
 		DB:       database,
 	})
 	store.loadSuperLargeDirectories(superLargeDirectories)
+	store.detectSupportLuaScript(context.Background())
 	return
 }

--- a/weed/filer/redis2/stored_procedure/delete_entry.lua
+++ b/weed/filer/redis2/stored_procedure/delete_entry.lua
@@ -1,0 +1,19 @@
+-- KEYS[1]: full path of entry
+local fullpath = KEYS[1]
+-- KEYS[2]: full path of entry
+local fullpath_list_key = KEYS[2]
+-- KEYS[3]: dir of the entry
+local dir_list_key = KEYS[3]
+
+-- ARGV[1]: isSuperLargeDirectory
+local isSuperLargeDirectory = ARGV[1] == "1"
+-- ARGV[2]: name of the entry
+local name = ARGV[2]
+
+redis.call("DEL", fullpath, fullpath_list_key)
+
+if not isSuperLargeDirectory and name ~= "" then
+    redis.call("ZREM", dir_list_key, name)
+end
+
+return 0

--- a/weed/filer/redis2/stored_procedure/delete_folder_children.lua
+++ b/weed/filer/redis2/stored_procedure/delete_folder_children.lua
@@ -1,0 +1,15 @@
+-- KEYS[1]: full path of entry
+local fullpath = KEYS[1]
+
+if fullpath ~= "" and string.sub(fullpath, -1) == "/" then
+    fullpath = string.sub(fullpath, 0, -2)
+end
+
+local files = redis.call("ZRANGE", fullpath .. "\0", "0", "-1")
+
+for _, name in ipairs(files) do
+    local file_path = fullpath .. "/" .. name
+    redis.call("DEL", file_path, file_path .. "\0")
+end
+
+return 0

--- a/weed/filer/redis2/stored_procedure/init.go
+++ b/weed/filer/redis2/stored_procedure/init.go
@@ -1,0 +1,24 @@
+package stored_procedure
+
+import (
+	_ "embed"
+	"github.com/go-redis/redis/v8"
+)
+
+func init() {
+	InsertEntryScript = redis.NewScript(insertEntry)
+	DeleteEntryScript = redis.NewScript(deleteEntry)
+	DeleteFolderChildrenScript = redis.NewScript(deleteFolderChildren)
+}
+
+//go:embed insert_entry.lua
+var insertEntry string
+var InsertEntryScript *redis.Script
+
+//go:embed delete_entry.lua
+var deleteEntry string
+var DeleteEntryScript *redis.Script
+
+//go:embed delete_folder_children.lua
+var deleteFolderChildren string
+var DeleteFolderChildrenScript *redis.Script

--- a/weed/filer/redis2/stored_procedure/insert_entry.lua
+++ b/weed/filer/redis2/stored_procedure/insert_entry.lua
@@ -1,0 +1,27 @@
+-- KEYS[1]: full path of entry
+local full_path = KEYS[1]
+-- KEYS[2]: dir of the entry
+local dir_list_key = KEYS[2]
+
+-- ARGV[1]: content of the entry
+local entry = ARGV[1]
+-- ARGV[2]: TTL of the entry
+local ttlSec = tonumber(ARGV[2])
+-- ARGV[3]: isSuperLargeDirectory
+local isSuperLargeDirectory = ARGV[3] == "1"
+-- ARGV[4]: zscore of the entry in zset
+local zscore = tonumber(ARGV[4])
+-- ARGV[5]: name of the entry
+local name = ARGV[5]
+
+if ttlSec > 0 then
+    redis.call("SET", full_path, entry, "EX", ttlSec)
+else
+    redis.call("SET", full_path, entry)
+end
+
+if not isSuperLargeDirectory and name ~= "" then
+    redis.call("ZADD", dir_list_key, "NX", zscore, name)
+end
+
+return 0


### PR DESCRIPTION
> ### [Atomicity of scripts](https://redis.io/commands/eval#atomicity-of-scripts)
>Redis uses the same Lua interpreter to run all the commands. Also Redis guarantees that **a script is executed in an atomic way**: no other script or Redis command will be executed while a script is being executed. This semantic is similar to the one of MULTI / EXEC. From the point of view of all the other clients the effects of a script are either still not visible or already completed.
However this also means that executing slow scripts is not a good idea. It is not hard to create fast scripts, as the script overhead is very low, but if you are going to use slow scripts you should be aware that while the script is running no other client can execute commands.