### PR TITLE
bugfix: padding zero for sparse file in web API

### DIFF
--- a/weed/filer/reader_at.go
+++ b/weed/filer/reader_at.go
@@ -129,7 +129,7 @@ func (c *ChunkReadAt) doReadAt(p []byte, offset int64) (n int, err error) {
 		}
 		if startOffset < chunk.LogicOffset {
 			gap := int(chunk.LogicOffset - startOffset)
-			glog.V(4).Infof("zero [%d,%d)", startOffset, startOffset+int64(gap))
+			glog.V(4).Infof("zero [%d,%d)", startOffset, chunk.LogicOffset)
 			n += int(min(int64(gap), remaining))
 			startOffset, remaining = chunk.LogicOffset, remaining-int64(gap)
 			if remaining <= 0 {


### PR DESCRIPTION
Padding zero for sparse file in web API like that in [FUSE](https://github.com/chrislusf/seaweedfs/blob/fe5b9e39cc5a3526a0fdadf8b518b67b02d5451b/weed/filer/reader_at.go#L132).