### PR TITLE
add s3api error for copy in file, not directory

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -436,10 +436,14 @@ func setEtag(w http.ResponseWriter, etag string) {
 }
 
 func filerErrorToS3Error(errString string) s3err.ErrorCode {
-	if strings.HasPrefix(errString, "existing ") && strings.HasSuffix(errString, "is a directory") {
+	switch {
+	case strings.HasPrefix(errString, "existing ") && strings.HasSuffix(errString, "is a directory"):
 		return s3err.ErrExistingObjectIsDirectory
+	case strings.HasSuffix(errString, "is a file"):
+		return s3err.ErrExistingObjectIsFile
+	default:
+		return s3err.ErrInternalError
 	}
-	return s3err.ErrInternalError
 }
 
 func (s3a *S3ApiServer) maybeAddFilerJwtAuthorization(r *http.Request, isWrite bool) {

--- a/weed/s3api/s3err/s3api_errors.go
+++ b/weed/s3api/s3err/s3api_errors.go
@@ -101,6 +101,7 @@ const (
 	ErrPreconditionFailed
 
 	ErrExistingObjectIsDirectory
+	ErrExistingObjectIsFile
 )
 
 // error code to APIError structure, these fields carry respective
@@ -381,6 +382,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrExistingObjectIsDirectory: {
 		Code:           "ExistingObjectIsDirectory",
 		Description:    "Existing Object is a directory.",
+		HTTPStatusCode: http.StatusConflict,
+	},
+	ErrExistingObjectIsFile: {
+		Code:           "ExistingObjectIsFile",
+		Description:    "Existing Object is a file.",
 		HTTPStatusCode: http.StatusConflict,
 	},
 }


### PR DESCRIPTION
weed/s3api/s3err/s3api_errors.go

When user try to copy some file into another file, he received only "500 Internal server error". This error not informative.

Add error - "ErrExistingObjectIsFile", when user try to copy file into file, he receive "409 Existing object is a file"
