### PR TITLE
Added basic deletion capabilities to fsck.

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -64,7 +64,7 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 	verbose := fsckCommand.Bool("v", false, "verbose mode")
 	findMissingChunksInFiler := fsckCommand.Bool("findMissingChunksInFiler", false, "see \"help volume.fsck\"")
 	findMissingChunksInFilerPath := fsckCommand.String("findMissingChunksInFilerPath", "/", "used together with findMissingChunksInFiler")
-	applyPurging := fsckCommand.Bool("purge", false, "<expert only!> after detection, delete missing data from volumes / delete missing file entries from filer")
+	applyPurging := fsckCommand.Bool("reallyDeleteFromVolume", false, "<expert only!> after detection, delete missing data from volumes / delete missing file entries from filer")
 	purgeAbsent := fsckCommand.Bool("purgeAbsent", false, "<expert only!> delete missing file entries from filer if the corresponding volume is missing for any reason, please ensure all still existing/expected volumes are connected! used together with findMissingChunksInFiler")
 	if err = fsckCommand.Parse(args); err != nil {
 		return nil

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -65,7 +65,7 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 	findMissingChunksInFiler := fsckCommand.Bool("findMissingChunksInFiler", false, "see \"help volume.fsck\"")
 	findMissingChunksInFilerPath := fsckCommand.String("findMissingChunksInFilerPath", "/", "used together with findMissingChunksInFiler")
 	applyPurging := fsckCommand.Bool("reallyDeleteFromVolume", false, "<expert only!> after detection, delete missing data from volumes / delete missing file entries from filer")
-	purgeAbsent := fsckCommand.Bool("purgeAbsent", false, "<expert only!> delete missing file entries from filer if the corresponding volume is missing for any reason, please ensure all still existing/expected volumes are connected! used together with findMissingChunksInFiler")
+	purgeAbsent := fsckCommand.Bool("reallyDeleteFilerEntries", false, "<expert only!> delete missing file entries from filer if the corresponding volume is missing for any reason, please ensure all still existing/expected volumes are connected! used together with findMissingChunksInFiler")
 	if err = fsckCommand.Parse(args); err != nil {
 		return nil
 	}


### PR DESCRIPTION
With your helpful feedback from #2605 , I added/fixed the option to delete missing files volumes<->in filer to volume.fsck. It does successfully get rid of the errors that volume.fsck can catch.

What wasn't implemented from the ideas in #2605 is an option to write lists of affected files for weed external review/consumption.

PS: I had to drop a small functionality that dropped a whole volume rather than sending filewise deletion requests when all entries were orphaned. It did not really work (haven't fully established the reason, but my guess was that not all additional replicas on all volume servers were removed). However "only" doing the usual filewise deletion seems fast enough and has to be used for 1+ files anyhow, so I went with just that.