### PR TITLE
Make heartbeat interval and election timeout of masters configurable.

### DIFF
--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -98,6 +98,8 @@ func init() {
 	masterOptions.metricsAddress = cmdServer.Flag.String("metrics.address", "", "Prometheus gateway address")
 	masterOptions.metricsIntervalSec = cmdServer.Flag.Int("metrics.intervalSeconds", 15, "Prometheus push interval in seconds")
 	masterOptions.raftResumeState = cmdServer.Flag.Bool("resumeState", false, "resume previous state on start master server")
+	masterOptions.heartbeatInterval = cmdServer.Flag.Duration("master.heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
+	masterOptions.electionTimeout = cmdServer.Flag.Duration("master.electionTimeout", 10*time.Second, "election timeout of master servers")
 
 	filerOptions.collection = cmdServer.Flag.String("filer.collection", "", "all data will be stored in this collection")
 	filerOptions.port = cmdServer.Flag.Int("filer.port", 8888, "filer server http listen port")


### PR DESCRIPTION
### Problem

Election timeout is fixed at 10 seconds. This means that when the leader dies, it takes 10 to 20 seconds to elect a new leader.
That may be too long for some people.  If the network between masters is good, I think a short election timeout is appropriate.

### Solution

Make heartbeat interval and election timeout of masters configurable. Therefore, we can configure them according to our actual situation.

### Usage

Specified on the command line, e.g.:

```shell
weed server --master.electionTimeout=3s --master.heartbeatInterval=300ms
```

Or specified in the configuration file, e.g:

```
# Run server with: weed server -options=server.conf
# The content of server.conf:
master.electionTimeout=3s
master.heartbeatInterval=300ms
```

