### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/weed/filer/leveldb/leveldb_store_test.go
+++ b/weed/filer/leveldb/leveldb_store_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestCreateAndFind(t *testing.T) {
 	testFiler := filer.NewFiler(nil, nil, "", "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	store := &LevelDBStore{}
 	store.initialize(dir)
 	testFiler.SetStore(store)
@@ -67,8 +66,7 @@ func TestCreateAndFind(t *testing.T) {
 
 func TestEmptyRoot(t *testing.T) {
 	testFiler := filer.NewFiler(nil, nil, "", "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_test2")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	store := &LevelDBStore{}
 	store.initialize(dir)
 	testFiler.SetStore(store)
@@ -90,8 +88,7 @@ func TestEmptyRoot(t *testing.T) {
 
 func BenchmarkInsertEntry(b *testing.B) {
 	testFiler := filer.NewFiler(nil, nil, "", "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_bench")
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 	store := &LevelDBStore{}
 	store.initialize(dir)
 	testFiler.SetStore(store)

--- a/weed/filer/leveldb2/leveldb2_store_test.go
+++ b/weed/filer/leveldb2/leveldb2_store_test.go
@@ -2,7 +2,6 @@ package leveldb
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/chrislusf/seaweedfs/weed/filer"
@@ -11,8 +10,7 @@ import (
 
 func TestCreateAndFind(t *testing.T) {
 	testFiler := filer.NewFiler(nil, nil, "", "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	store := &LevelDB2Store{}
 	store.initialize(dir, 2)
 	testFiler.SetStore(store)
@@ -65,8 +63,7 @@ func TestCreateAndFind(t *testing.T) {
 
 func TestEmptyRoot(t *testing.T) {
 	testFiler := filer.NewFiler(nil, nil, "", "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_test2")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	store := &LevelDB2Store{}
 	store.initialize(dir, 2)
 	testFiler.SetStore(store)

--- a/weed/filer/leveldb3/leveldb3_store_test.go
+++ b/weed/filer/leveldb3/leveldb3_store_test.go
@@ -2,7 +2,6 @@ package leveldb
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/chrislusf/seaweedfs/weed/filer"
@@ -11,8 +10,7 @@ import (
 
 func TestCreateAndFind(t *testing.T) {
 	testFiler := filer.NewFiler(nil, nil, "", "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	store := &LevelDB3Store{}
 	store.initialize(dir)
 	testFiler.SetStore(store)
@@ -65,8 +63,7 @@ func TestCreateAndFind(t *testing.T) {
 
 func TestEmptyRoot(t *testing.T) {
 	testFiler := filer.NewFiler(nil, nil, "", "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_test2")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	store := &LevelDB3Store{}
 	store.initialize(dir)
 	testFiler.SetStore(store)

--- a/weed/filer/rocksdb/rocksdb_store_test.go
+++ b/weed/filer/rocksdb/rocksdb_store_test.go
@@ -16,8 +16,7 @@ import (
 
 func TestCreateAndFind(t *testing.T) {
 	testFiler := filer.NewFiler(nil, nil, "", 0, "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	store := &RocksDBStore{}
 	store.initialize(dir)
 	testFiler.SetStore(store)
@@ -70,8 +69,7 @@ func TestCreateAndFind(t *testing.T) {
 
 func TestEmptyRoot(t *testing.T) {
 	testFiler := filer.NewFiler(nil, nil, "", 0, "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_test2")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	store := &RocksDBStore{}
 	store.initialize(dir)
 	testFiler.SetStore(store)
@@ -93,8 +91,7 @@ func TestEmptyRoot(t *testing.T) {
 
 func BenchmarkInsertEntry(b *testing.B) {
 	testFiler := filer.NewFiler(nil, nil, "", 0, "", "", "", nil)
-	dir, _ := os.MkdirTemp("", "seaweedfs_filer_bench")
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 	store := &RocksDBStore{}
 	store.initialize(dir)
 	testFiler.SetStore(store)

--- a/weed/storage/volume_vacuum_test.go
+++ b/weed/storage/volume_vacuum_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -62,11 +61,7 @@ func TestMakeDiff(t *testing.T) {
 }
 
 func TestCompaction(t *testing.T) {
-	dir, err := os.MkdirTemp("", "example")
-	if err != nil {
-		t.Fatalf("temp dir creation: %v", err)
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	v, err := NewVolume(dir, dir, "", 1, NeedleMapInMemory, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, 0)
 	if err != nil {

--- a/weed/storage/volume_write_test.go
+++ b/weed/storage/volume_write_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -12,11 +11,7 @@ import (
 )
 
 func TestSearchVolumesWithDeletedNeedles(t *testing.T) {
-	dir, err := os.MkdirTemp("", "example")
-	if err != nil {
-		t.Fatalf("temp dir creation: %v", err)
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	v, err := NewVolume(dir, dir, "", 1, NeedleMapInMemory, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, 0)
 	if err != nil {

--- a/weed/util/chunk_cache/chunk_cache_on_disk_test.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk_test.go
@@ -4,14 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 )
 
 func TestOnDisk(t *testing.T) {
-
-	tmpDir, _ := os.MkdirTemp("", "c")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	totalDiskSizeInKB := int64(32)
 


### PR DESCRIPTION
A small testing enhancement here.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir