### PR TITLE
weed/operation/delete_content.go: nil pointer dereference

### DIFF
--- a/weed/operation/delete_content.go
+++ b/weed/operation/delete_content.go
@@ -81,7 +81,7 @@ func DeleteFilesWithLookupVolumeId(grpcDialOption grpc.DialOption, fileIds []str
 			ret = append(ret, &volume_server_pb.DeleteResult{
 				FileId: vid,
 				Status: http.StatusBadRequest,
-				Error:  err.Error()},
+				Error:  result.Error},
 			)
 			continue
 		}


### PR DESCRIPTION
> goroutine 99 [running]:
github.com/chrislusf/seaweedfs/weed/operation.DeleteFilesWithLookupVolumeId({0x2846780, 0xc00000f6f8}, {0xc0030ce000, 0x1b6, 0x200}, 0xc000739ac8)
        /github/workspace/weed/operation/delete_content.go:84 +0x327
github.com/chrislusf/seaweedfs/weed/operation.DeleteFiles(0x1eef320, 0x0, {0x2846780, 0xc00000f6f8}, {0xc0030ce000, 0x2, 0x2})
        /github/workspace/weed/operation/delete_content.go:46 +0x85
github.com/chrislusf/seaweedfs/weed/command.(*FileCopyWorker).uploadFileInChunks(0xc000116768, {{0x7fff6da912c4, 0x21}, {0x7fff6da94111, 0x1a}, 0x6de98640, 0x1b4, 0x3e8, 0x3e8}, 0xc00000fbe8, ...)
        /github/workspace/weed/command/filer_copy.go:533 +0xbaf
github.com/chrislusf/seaweedfs/weed/command.(*FileCopyWorker).doEachCopy(0xc000116768, {{0x7fff6da912c4, 0x21}, {0x7fff6da94111, 0x1a}, 0x6de98640, 0x1b4, 0x3e8, 0x3e8})
        /github/workspace/weed/command/filer_copy.go:288 +0x370
github.com/chrislusf/seaweedfs/weed/command.(*FileCopyWorker).copyFiles(0x0, 0x0)
        /github/workspace/weed/command/filer_copy.go:232 +0x11a
github.com/chrislusf/seaweedfs/weed/command.runCopy.func2()
        /github/workspace/weed/command/filer_copy.go:163 +0xcf
created by github.com/chrislusf/seaweedfs/weed/command.runCopy
        /github/workspace/weed/command/filer_copy.go:157 +0x865
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xb21c47]