### PR TITLE
filer: support get file entry

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -21,7 +21,6 @@ import (
 	"github.com/chrislusf/seaweedfs/weed/util"
 )
 
-
 // Validates the preconditions. Returns true if GET/HEAD operation should not proceed.
 // Preconditions supported are:
 //  If-Modified-Since
@@ -116,6 +115,11 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 
 	if isForDirectory {
 		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if r.URL.Query().Has("metadata") {
+		writeJsonQuiet(w, r, http.StatusOK, entry)
 		return
 	}
 


### PR DESCRIPTION
Currently, we can get all entries under a directory by [List files under a directory](https://github.com/chrislusf/seaweedfs/wiki/Filer-Server-API#list-files-under-a-directory):
```bash
curl -H "Accept: application/json" "http://localhost:8888/javascript/?pretty=y&lastFileName=jquery-2.1.3.min.js&limit=2"
```

This PR add support to getting the entry of a file by adding "entry" parameter like below:

```bash
> curl 'http://localhost:8888/test01.py?entry&pretty=yes'
{
  "FullPath": "/test01.py",
  "Mtime": "2022-01-09T19:11:18+08:00",
  "Crtime": "2022-01-09T19:11:18+08:00",
  "Mode": 432,
  "Uid": 1001,
  "Gid": 1001,
  "Mime": "text/x-python",
  "Replication": "",
  "Collection": "",
  "TtlSec": 0,
  "DiskType": "",
  "UserName": "",
  "GroupNames": null,
  "SymlinkTarget": "",
  "Md5": "px6as5eP7tF5YcgAv5m60Q==",
  "FileSize": 1992,
  "Extended": null,
  "chunks": [
    {
      "file_id": "17,04fbb55507b515",
      "size": 1992,
      "mtime": 1641726678984876713,
      "e_tag": "px6as5eP7tF5YcgAv5m60Q==",
      "fid": {
        "volume_id": 17,
        "file_key": 326581,
        "cookie": 1426568469
      },
      "is_compressed": true
    }
  ],
  "HardLinkId": null,
  "HardLinkCounter": 0,
  "Content": null,
  "Remote": null,
  "Quota": 0
}
```