### PR TITLE
filer: support shallow copy file

### DIFF
--- a/weed/server/filer_copy.go
+++ b/weed/server/filer_copy.go
@@ -1,0 +1,219 @@
+package weed_server
+
+import (
+	"context"
+	"fmt"
+	"github.com/chrislusf/seaweedfs/weed/operation"
+	"strings"
+	"time"
+
+	"github.com/chrislusf/seaweedfs/weed/filer"
+	"github.com/chrislusf/seaweedfs/weed/glog"
+	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
+	"github.com/chrislusf/seaweedfs/weed/util"
+)
+
+func (fs *FilerServer) Copy(ctx context.Context, stream filer_pb.SeaweedFiler_StreamRenameEntryServer, src, dst string, so *operation.StorageOption, deleteSource bool) (err error) {
+	glog.V(2).Infof("FilerServer.copy %v to %v", src, dst)
+
+	if src, err = clearName(src); err != nil {
+		return
+	}
+	if dst, err = clearName(dst); err != nil {
+		return
+	}
+	src = strings.TrimRight(src, "/")
+	if src == "" {
+		err = fmt.Errorf("invalid source '/'")
+		return
+	}
+
+	srcPath := util.FullPath(src)
+	dstPath := util.FullPath(dst)
+	srcEntry, err := fs.filer.FindEntry(ctx, srcPath)
+	if err != nil {
+		err = fmt.Errorf("failed to get src entry '%s', err: %s", src, err)
+		return
+	}
+
+	oldDir, oldName := srcPath.DirAndName()
+	newDir, newName := dstPath.DirAndName()
+	newName = util.Nvl(newName, oldName)
+
+	dstEntry, err := fs.filer.FindEntry(ctx, util.FullPath(strings.TrimRight(dst, "/")))
+	if err != nil && err != filer_pb.ErrNotFound {
+		err = fmt.Errorf("failed to get dst entry '%s', err: %s", dst, err)
+		return
+	}
+	if err == nil && !dstEntry.IsDirectory() && srcEntry.IsDirectory() {
+		err = fmt.Errorf("copy: cannot overwrite non-directory '%s' with directory '%s'", dst, src)
+		return
+	}
+
+	err = fs.atomicCopyEntry(ctx, stream, oldDir, oldName, newDir, newName, nil, deleteSource)
+	if err != nil {
+		err = fmt.Errorf("failed to copy entry from '%s' to '%s', err: %s", src, dst, err)
+		return
+	}
+
+	return
+}
+
+func (fs *FilerServer) atomicCopyEntry(ctx context.Context, stream filer_pb.SeaweedFiler_StreamRenameEntryServer, srcDir, srcName, dstDir, dstName string, signatures []int32, deleteSource bool) error {
+	oldParent := util.FullPath(srcDir)
+	newParent := util.FullPath(dstDir)
+
+	if err := fs.filer.CanRename(oldParent, newParent); err != nil {
+		return err
+	}
+
+	ctx, err := fs.filer.BeginTransaction(ctx)
+	if err != nil {
+		return err
+	}
+
+	oldEntry, err := fs.filer.FindEntry(ctx, oldParent.Child(srcName))
+	if err != nil {
+		fs.filer.RollbackTransaction(ctx)
+		return fmt.Errorf("%s/%s not found: %v", srcDir, srcName, err)
+	}
+
+	moveErr := fs.copyEntry(ctx, stream, oldParent, oldEntry, newParent, dstName, signatures, deleteSource)
+	if moveErr != nil {
+		fs.filer.RollbackTransaction(ctx)
+		return fmt.Errorf("%s/%s move error: %v", srcDir, srcName, moveErr)
+	} else {
+		if commitError := fs.filer.CommitTransaction(ctx); commitError != nil {
+			fs.filer.RollbackTransaction(ctx)
+			return fmt.Errorf("%s/%s move commit error: %v", srcDir, srcName, commitError)
+		}
+	}
+
+	return nil
+}
+
+func (fs *FilerServer) copyEntry(ctx context.Context, stream filer_pb.SeaweedFiler_StreamRenameEntryServer, oldParent util.FullPath, entry *filer.Entry, newParent util.FullPath, newName string, signatures []int32, deleteSource bool) error {
+
+	if err := fs.copySelfEntry(ctx, stream, oldParent, entry, newParent, newName, deleteSource, func() error {
+		if entry.IsDirectory() {
+			if err := fs.copyFolderSubEntries(ctx, stream, oldParent, entry, newParent, newName, signatures, deleteSource); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, signatures); err != nil {
+		return fmt.Errorf("fail to copy %s => %s: %v", oldParent.Child(entry.Name()), newParent.Child(newName), err)
+	}
+
+	return nil
+}
+
+func (fs *FilerServer) copyFolderSubEntries(ctx context.Context, stream filer_pb.SeaweedFiler_StreamRenameEntryServer, oldParent util.FullPath, entry *filer.Entry, newParent util.FullPath, newName string, signatures []int32, deleteSource bool) error {
+
+	currentDirPath := oldParent.Child(entry.Name())
+	newDirPath := newParent.Child(newName)
+
+	glog.V(1).Infof("moving folder %s => %s", currentDirPath, newDirPath)
+
+	lastFileName := ""
+	includeLastFile := false
+	for {
+
+		entries, hasMore, err := fs.filer.ListDirectoryEntries(ctx, currentDirPath, lastFileName, includeLastFile, 1024, "", "", "")
+		if err != nil {
+			return err
+		}
+
+		// println("found", len(entries), "entries under", currentDirPath)
+
+		for _, item := range entries {
+			lastFileName = item.Name()
+			// println("processing", lastFileName)
+			err := fs.copyEntry(ctx, stream, currentDirPath, item, newDirPath, item.Name(), signatures, deleteSource)
+			if err != nil {
+				return err
+			}
+		}
+		if !hasMore {
+			break
+		}
+	}
+	return nil
+}
+
+func (fs *FilerServer) copySelfEntry(ctx context.Context, stream filer_pb.SeaweedFiler_StreamRenameEntryServer, oldParent util.FullPath, entry *filer.Entry, newParent util.FullPath, newName string, deleteSource bool, copyFolderSubEntries func() error, signatures []int32) error {
+
+	oldPath, newPath := oldParent.Child(entry.Name()), newParent.Child(newName)
+
+	glog.V(1).Infof("moving entry %s => %s", oldPath, newPath)
+
+	if oldPath == newPath {
+		glog.V(1).Infof("skip moving entry %s => %s", oldPath, newPath)
+		return nil
+	}
+
+	// add to new directory
+	newEntry := &filer.Entry{
+		FullPath: newPath,
+		Attr:     entry.Attr,
+		Chunks:   entry.Chunks,
+		Extended: entry.Extended,
+		Content:  entry.Content,
+	}
+	if createErr := fs.filer.CreateEntry(ctx, newEntry, false, false, signatures); createErr != nil {
+		return createErr
+	}
+	if stream != nil {
+		if err := stream.Send(&filer_pb.StreamRenameEntryResponse{
+			Directory: string(oldParent),
+			EventNotification: &filer_pb.EventNotification{
+				OldEntry: &filer_pb.Entry{
+					Name: entry.Name(),
+				},
+				NewEntry:           newEntry.ToProtoEntry(),
+				DeleteChunks:       false,
+				NewParentPath:      string(newParent),
+				IsFromOtherCluster: false,
+				Signatures:         nil,
+			},
+			TsNs: time.Now().UnixNano(),
+		}); err != nil {
+			return err
+		}
+	}
+
+	if copyFolderSubEntries != nil {
+		if copyChildrenErr := copyFolderSubEntries(); copyChildrenErr != nil {
+			return copyChildrenErr
+		}
+	}
+
+	// delete old entry
+	if deleteSource {
+		deleteErr := fs.filer.DeleteEntryMetaAndData(ctx, oldPath, false, false, false, false, signatures)
+		if deleteErr != nil {
+			return deleteErr
+		}
+		if stream != nil {
+			if err := stream.Send(&filer_pb.StreamRenameEntryResponse{
+				Directory: string(oldParent),
+				EventNotification: &filer_pb.EventNotification{
+					OldEntry: &filer_pb.Entry{
+						Name: entry.Name(),
+					},
+					NewEntry:           nil,
+					DeleteChunks:       false,
+					NewParentPath:      "",
+					IsFromOtherCluster: false,
+					Signatures:         nil,
+				},
+				TsNs: time.Now().UnixNano(),
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+
+}

--- a/weed/server/filer_grpc_server_rename.go
+++ b/weed/server/filer_grpc_server_rename.go
@@ -3,49 +3,22 @@ package weed_server
 import (
 	"context"
 	"fmt"
-	"path/filepath"
-	"time"
-
-	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
 	"github.com/chrislusf/seaweedfs/weed/util"
+	"path/filepath"
 )
 
 func (fs *FilerServer) AtomicRenameEntry(ctx context.Context, req *filer_pb.AtomicRenameEntryRequest) (*filer_pb.AtomicRenameEntryResponse, error) {
 
 	glog.V(1).Infof("AtomicRenameEntry %v", req)
 
-	oldParent := util.FullPath(filepath.ToSlash(req.OldDirectory))
-	newParent := util.FullPath(filepath.ToSlash(req.NewDirectory))
-
-	if err := fs.filer.CanRename(oldParent, newParent); err != nil {
+	if err := fs.Copy(ctx, nil, req.OldDirectory, req.NewDirectory, nil, true); err != nil {
 		return nil, err
-	}
-
-	ctx, err := fs.filer.BeginTransaction(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	oldEntry, err := fs.filer.FindEntry(ctx, oldParent.Child(req.OldName))
-	if err != nil {
-		fs.filer.RollbackTransaction(ctx)
-		return nil, fmt.Errorf("%s/%s not found: %v", req.OldDirectory, req.OldName, err)
-	}
-
-	moveErr := fs.moveEntry(ctx, nil, oldParent, oldEntry, newParent, req.NewName, req.Signatures)
-	if moveErr != nil {
-		fs.filer.RollbackTransaction(ctx)
-		return nil, fmt.Errorf("%s/%s move error: %v", req.OldDirectory, req.OldName, moveErr)
 	} else {
-		if commitError := fs.filer.CommitTransaction(ctx); commitError != nil {
-			fs.filer.RollbackTransaction(ctx)
-			return nil, fmt.Errorf("%s/%s move commit error: %v", req.OldDirectory, req.OldName, commitError)
-		}
+		return &filer_pb.AtomicRenameEntryResponse{}, nil
 	}
 
-	return &filer_pb.AtomicRenameEntryResponse{}, nil
 }
 
 func (fs *FilerServer) StreamRenameEntry(req *filer_pb.StreamRenameEntryRequest, stream filer_pb.SeaweedFiler_StreamRenameEntryServer) (err error) {
@@ -87,7 +60,7 @@ func (fs *FilerServer) StreamRenameEntry(req *filer_pb.StreamRenameEntryRequest,
 		}
 	}
 
-	moveErr := fs.moveEntry(ctx, stream, oldParent, oldEntry, newParent, req.NewName, req.Signatures)
+	moveErr := fs.copyEntry(ctx, stream, oldParent, oldEntry, newParent, req.NewName, req.Signatures, true)
 	if moveErr != nil {
 		fs.filer.RollbackTransaction(ctx)
 		return fmt.Errorf("%s/%s move error: %v", req.OldDirectory, req.OldName, moveErr)
@@ -99,128 +72,4 @@ func (fs *FilerServer) StreamRenameEntry(req *filer_pb.StreamRenameEntryRequest,
 	}
 
 	return nil
-}
-
-func (fs *FilerServer) moveEntry(ctx context.Context, stream filer_pb.SeaweedFiler_StreamRenameEntryServer, oldParent util.FullPath, entry *filer.Entry, newParent util.FullPath, newName string, signatures []int32) error {
-
-	if err := fs.moveSelfEntry(ctx, stream, oldParent, entry, newParent, newName, func() error {
-		if entry.IsDirectory() {
-			if err := fs.moveFolderSubEntries(ctx, stream, oldParent, entry, newParent, newName, signatures); err != nil {
-				return err
-			}
-		}
-		return nil
-	}, signatures); err != nil {
-		return fmt.Errorf("fail to move %s => %s: %v", oldParent.Child(entry.Name()), newParent.Child(newName), err)
-	}
-
-	return nil
-}
-
-func (fs *FilerServer) moveFolderSubEntries(ctx context.Context, stream filer_pb.SeaweedFiler_StreamRenameEntryServer, oldParent util.FullPath, entry *filer.Entry, newParent util.FullPath, newName string, signatures []int32) error {
-
-	currentDirPath := oldParent.Child(entry.Name())
-	newDirPath := newParent.Child(newName)
-
-	glog.V(1).Infof("moving folder %s => %s", currentDirPath, newDirPath)
-
-	lastFileName := ""
-	includeLastFile := false
-	for {
-
-		entries, hasMore, err := fs.filer.ListDirectoryEntries(ctx, currentDirPath, lastFileName, includeLastFile, 1024, "", "", "")
-		if err != nil {
-			return err
-		}
-
-		// println("found", len(entries), "entries under", currentDirPath)
-
-		for _, item := range entries {
-			lastFileName = item.Name()
-			// println("processing", lastFileName)
-			err := fs.moveEntry(ctx, stream, currentDirPath, item, newDirPath, item.Name(), signatures)
-			if err != nil {
-				return err
-			}
-		}
-		if !hasMore {
-			break
-		}
-	}
-	return nil
-}
-
-func (fs *FilerServer) moveSelfEntry(ctx context.Context, stream filer_pb.SeaweedFiler_StreamRenameEntryServer, oldParent util.FullPath, entry *filer.Entry, newParent util.FullPath, newName string, moveFolderSubEntries func() error, signatures []int32) error {
-
-	oldPath, newPath := oldParent.Child(entry.Name()), newParent.Child(newName)
-
-	glog.V(1).Infof("moving entry %s => %s", oldPath, newPath)
-
-	if oldPath == newPath {
-		glog.V(1).Infof("skip moving entry %s => %s", oldPath, newPath)
-		return nil
-	}
-
-	// add to new directory
-	newEntry := &filer.Entry{
-		FullPath: newPath,
-		Attr:     entry.Attr,
-		Chunks:   entry.Chunks,
-		Extended: entry.Extended,
-		Content:  entry.Content,
-	}
-	if createErr := fs.filer.CreateEntry(ctx, newEntry, false, false, signatures); createErr != nil {
-		return createErr
-	}
-	if stream != nil {
-		if err := stream.Send(&filer_pb.StreamRenameEntryResponse{
-			Directory: string(oldParent),
-			EventNotification: &filer_pb.EventNotification{
-				OldEntry: &filer_pb.Entry{
-					Name: entry.Name(),
-				},
-				NewEntry:           newEntry.ToProtoEntry(),
-				DeleteChunks:       false,
-				NewParentPath:      string(newParent),
-				IsFromOtherCluster: false,
-				Signatures:         nil,
-			},
-			TsNs: time.Now().UnixNano(),
-		}); err != nil {
-			return err
-		}
-	}
-
-	if moveFolderSubEntries != nil {
-		if moveChildrenErr := moveFolderSubEntries(); moveChildrenErr != nil {
-			return moveChildrenErr
-		}
-	}
-
-	// delete old entry
-	deleteErr := fs.filer.DeleteEntryMetaAndData(ctx, oldPath, false, false, false, false, signatures)
-	if deleteErr != nil {
-		return deleteErr
-	}
-	if stream != nil {
-		if err := stream.Send(&filer_pb.StreamRenameEntryResponse{
-			Directory: string(oldParent),
-			EventNotification: &filer_pb.EventNotification{
-				OldEntry: &filer_pb.Entry{
-					Name: entry.Name(),
-				},
-				NewEntry:           nil,
-				DeleteChunks:       false,
-				NewParentPath:      "",
-				IsFromOtherCluster: false,
-				Signatures:         nil,
-			},
-			TsNs: time.Now().UnixNano(),
-		}); err != nil {
-			return err
-		}
-	}
-
-	return nil
-
 }

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -3,7 +3,6 @@ package weed_server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -80,75 +79,21 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, conte
 	}
 
 	if query.Has("from") {
-		fs.move(ctx, w, r, so)
+		src := query.Get("from")
+		dst := r.URL.Path
+		deleteSource := query.Get("deleteSource") == "true"
+
+		if err := fs.Copy(ctx, nil, src, dst, so, deleteSource); err != nil {
+			writeJsonError(w, r, http.StatusBadRequest, err)
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
 	} else {
 		fs.autoChunk(ctx, w, r, contentLength, so)
 	}
 
 	util.CloseRequest(r)
 
-}
-
-func (fs *FilerServer) move(ctx context.Context, w http.ResponseWriter, r *http.Request, so *operation.StorageOption) {
-	src := r.URL.Query().Get("from")
-	dst := r.URL.Path
-
-	glog.V(2).Infof("FilerServer.move %v to %v", src, dst)
-
-	var err error
-	if src, err = clearName(src); err != nil {
-		writeJsonError(w, r, http.StatusBadRequest, err)
-		return
-	}
-	if dst, err = clearName(dst); err != nil {
-		writeJsonError(w, r, http.StatusBadRequest, err)
-		return
-	}
-	src = strings.TrimRight(src, "/")
-	if src == "" {
-		err = fmt.Errorf("invalid source '/'")
-		writeJsonError(w, r, http.StatusBadRequest, err)
-		return
-	}
-
-	srcPath := util.FullPath(src)
-	dstPath := util.FullPath(dst)
-	srcEntry, err := fs.filer.FindEntry(ctx, srcPath)
-	if err != nil {
-		err = fmt.Errorf("failed to get src entry '%s', err: %s", src, err)
-		writeJsonError(w, r, http.StatusBadRequest, err)
-		return
-	}
-
-	oldDir, oldName := srcPath.DirAndName()
-	newDir, newName := dstPath.DirAndName()
-	newName = util.Nvl(newName, oldName)
-
-	dstEntry, err := fs.filer.FindEntry(ctx, util.FullPath(strings.TrimRight(dst, "/")))
-	if err != nil && err != filer_pb.ErrNotFound {
-		err = fmt.Errorf("failed to get dst entry '%s', err: %s", dst, err)
-		writeJsonError(w, r, http.StatusInternalServerError, err)
-		return
-	}
-	if err == nil && !dstEntry.IsDirectory() && srcEntry.IsDirectory() {
-		err = fmt.Errorf("move: cannot overwrite non-directory '%s' with directory '%s'", dst, src)
-		writeJsonError(w, r, http.StatusBadRequest, err)
-		return
-	}
-
-	_, err = fs.AtomicRenameEntry(ctx, &filer_pb.AtomicRenameEntryRequest{
-		OldDirectory: oldDir,
-		OldName:      oldName,
-		NewDirectory: newDir,
-		NewName:      newName,
-	})
-	if err != nil {
-		err = fmt.Errorf("failed to move entry from '%s' to '%s', err: %s", src, dst, err)
-		writeJsonError(w, r, http.StatusBadRequest, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusNoContent)
 }
 
 // curl -X DELETE http://localhost:8888/path/to


### PR DESCRIPTION
This can be used to take snapshots for files and directories.
```bash
# copy files and directories
> curl -X POST 'http://localhost:8888/path/to/dst_file?from=/path/2/src_file&deleteSource=false&pretty=yes'
# move files and directories
> curl -X POST 'http://localhost:8888/path/to/dst_file?from=/path/2/src_file&deleteSource=true&pretty=yes'