### PR TITLE
Set default leveldb2 enabled

### DIFF
--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -130,8 +130,8 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	go fs.filer.KeepMasterClientConnected()
 
 	if !util.LoadConfiguration("filer", false) {
-		v.Set("leveldb2.enabled", true)
-		v.Set("leveldb2.dir", option.DefaultLevelDbDir)
+		v.SetDefault("leveldb2.enabled", true)
+		v.SetDefault("leveldb2.dir", option.DefaultLevelDbDir)
 		_, err := os.Stat(option.DefaultLevelDbDir)
 		if os.IsNotExist(err) {
 			os.MkdirAll(option.DefaultLevelDbDir, 0755)


### PR DESCRIPTION
avoid Filer store is enabled for both leveldb2 and mysql if without config