### PR TITLE
filer: support get metadata with resolved manifest chunk

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -119,7 +119,16 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if r.URL.Query().Has("metadata") {
+	query := r.URL.Query()
+	if query.Get("metadata") == "true" {
+		if query.Get("resolveManifest") == "true" {
+			if entry.Chunks, _, err = filer.ResolveChunkManifest(
+				fs.filer.MasterClient.GetLookupFileIdFunction(),
+				entry.Chunks, 0, int64(entry.Size())); err != nil {
+				err = fmt.Errorf("failed to resolve chunk manifest, err: %s", err.Error())
+				writeJsonError(w, r, http.StatusInternalServerError, err)
+			}
+		}
 		writeJsonQuiet(w, r, http.StatusOK, entry)
 		return
 	}


### PR DESCRIPTION
Some chunks in the metadata is manifest, which is not usable for client to get chunk checksum.
```bash
curl  -H "Accept: application/json" "http://localhost:8888/weed?metadata&resolveManifest=true&pretty=yes"
```