### PR TITLE
[bugfix] filer: nil pointer dereference

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -149,7 +149,7 @@ func runFiler(cmd *Command, args []string) bool {
 		}()
 		startDelay++
 	} else {
-		f.localSocket = nil
+		*f.localSocket = ""
 	}
 
 	if *filerStartWebDav {


### PR DESCRIPTION
run with `./weed filer -port=8888 -master=localhost:9333` outputs:

> I0307 22:46:41  8700 filer_server.go:139] default to create filer store dir in ./filerldb2
> I0307 22:46:41  8700 leveldb2_store.go:42] filer store leveldb2 dir: ./filerldb2
> I0307 22:46:41  8700 file_util.go:23] Folder ./filerldb2 Permission: -rwxr-xr-x
> I0307 22:46:41  8700 filer.go:124] existing filer.store.id = 1880000011
> I0307 22:46:41  8700 configuration.go:28] configured filer store to leveldb2
> I0307 22:46:41  8700 filer.go:89] the cluster has 1 filers
> I0307 22:46:41  8700 filer.go:230] Start Seaweed Filer 30GB 2.93  at 192.168.15.128:8888
> panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1d69ef8]
> 
> goroutine 1 [running]:
> github.com/chrislusf/seaweedfs/weed/command.(*FilerOptions).startFiler(0x3d6f120)
>         /seaweedfs/weed/command/filer.go:240 +0x7b8
> github.com/chrislusf/seaweedfs/weed/command.runFiler(0x3c8cc78, {0xc00004e0e0, 0x2, 0x2})
>         /seaweedfs/weed/command/filer.go:175 +0x3e6
> main.main()
>         /seaweedfs/weed/weed.go:78 +0x3a3