### PR TITLE
fix:support some databases which not support 'IF NOT EXISTS' keyword.

### DIFF
--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/chrislusf/seaweedfs/weed/filer"
@@ -82,7 +83,7 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 		return fmt.Errorf("connect to %s error:%v", sqlUrl, err)
 	}
 
-	if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
+	if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil && !strings.Contains(err.Error(), "table already exist") {
 		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 	}
 


### PR DESCRIPTION
support some databases(such as:[BaikalDB)](https://github.com/baidu/BaikalDB) which not support `IF NOT EXISTS` keyword in the `create table` command.

<img width="522" alt="wecom-temp-4df2e3090c3a103d08643e383a802190" src="https://user-images.githubusercontent.com/10348876/157596963-6a8090ef-d656-4a9f-9fc4-cc96b779d46a.png">
 