### PR TITLE
filer: refactor fullpath to handle invalid path

### DIFF
--- a/weed/server/filer_grpc_server_remote.go
+++ b/weed/server/filer_grpc_server_remote.go
@@ -21,7 +21,7 @@ import (
 func (fs *FilerServer) CacheRemoteObjectToLocalCluster(ctx context.Context, req *filer_pb.CacheRemoteObjectToLocalClusterRequest) (*filer_pb.CacheRemoteObjectToLocalClusterResponse, error) {
 
 	// load all mappings
-	mappingEntry, err := fs.filer.FindEntry(ctx, util.JoinPath(filer.DirectoryEtcRemote, filer.REMOTE_STORAGE_MOUNT_FILE))
+	mappingEntry, err := fs.filer.FindEntry(ctx, util.NewFullPath(filer.DirectoryEtcRemote, filer.REMOTE_STORAGE_MOUNT_FILE))
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (fs *FilerServer) CacheRemoteObjectToLocalCluster(ctx context.Context, req 
 	}
 
 	// find storage configuration
-	storageConfEntry, err := fs.filer.FindEntry(ctx, util.JoinPath(filer.DirectoryEtcRemote, remoteStorageMountedLocation.Name+filer.REMOTE_STORAGE_CONF_SUFFIX))
+	storageConfEntry, err := fs.filer.FindEntry(ctx, util.NewFullPath(filer.DirectoryEtcRemote, remoteStorageMountedLocation.Name+filer.REMOTE_STORAGE_CONF_SUFFIX))
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (fs *FilerServer) CacheRemoteObjectToLocalCluster(ctx context.Context, req 
 	}
 
 	// find the entry
-	entry, err := fs.filer.FindEntry(ctx, util.JoinPath(req.Directory, req.Name))
+	entry, err := fs.filer.FindEntry(ctx, util.NewFullPath(req.Directory, req.Name))
 	if err == filer_pb.ErrNotFound {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (fs *FilerServer) CacheRemoteObjectToLocalCluster(ctx context.Context, req 
 		chunkCount = entry.Remote.RemoteSize/chunkSize + 1
 	}
 
-	dest := util.FullPath(remoteStorageMountedLocation.Path).Child(string(util.FullPath(req.Directory).Child(req.Name))[len(localMountedDir):])
+	dest := util.NewFullPath(remoteStorageMountedLocation.Path, util.Join(req.Directory, req.Name)[len(util.Join(localMountedDir)):])
 
 	var chunks []*filer_pb.FileChunk
 	var fetchAndWriteErr error

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -17,6 +17,8 @@ func (fs *FilerServer) filerHandler(w http.ResponseWriter, r *http.Request) {
 
 	start := time.Now()
 
+	r.URL.Path = string(util.NewFullPath(r.URL.Path))
+
 	if r.Method == "OPTIONS" {
 		stats.FilerRequestCounter.WithLabelValues("options").Inc()
 		OptionsHandler(w, r, false)

--- a/weed/util/fullpath.go
+++ b/weed/util/fullpath.go
@@ -6,15 +6,19 @@ import (
 	"strings"
 )
 
+// FullPath will keep the literal passed in.
+// file literal: /path/to/file
+// directory literal: /path/
+// change to file literal: fp.Child(".") or NewFullPath(name, ".")
+// change to directory literal: fp.Child("./") or NewFullPath(name, "./")
 type FullPath string
 
-func NewFullPath(dir, name string) FullPath {
-	return FullPath(dir).Child(name)
+func NewFullPath(name ...string) FullPath {
+	return FullPath(Join(name...))
 }
 
 func (fp FullPath) DirAndName() (string, string) {
-	dir, name := filepath.Split(string(fp))
-	name = strings.ToValidUTF8(name, "?")
+	dir, name := filepath.Split(clearName(string(fp)))
 	if dir == "/" {
 		return dir, name
 	}
@@ -24,6 +28,22 @@ func (fp FullPath) DirAndName() (string, string) {
 	return dir[:len(dir)-1], name
 }
 
+func (fp FullPath) ToDir() FullPath {
+	return fp.Child("./")
+}
+
+func (fp FullPath) ToFile() FullPath {
+	return fp.Child(".")
+}
+
+func (fp FullPath) IsFile() bool {
+	return !fp.IsDir()
+}
+
+func (fp FullPath) IsDir() bool {
+	return strings.HasSuffix(string(fp), "/")
+}
+
 func (fp FullPath) Name() string {
 	_, name := filepath.Split(string(fp))
 	name = strings.ToValidUTF8(name, "?")
@@ -31,15 +51,7 @@ func (fp FullPath) Name() string {
 }
 
 func (fp FullPath) Child(name string) FullPath {
-	dir := string(fp)
-	noPrefix := name
-	if strings.HasPrefix(name, "/") {
-		noPrefix = name[1:]
-	}
-	if strings.HasSuffix(dir, "/") {
-		return FullPath(dir + noPrefix)
-	}
-	return FullPath(dir + "/" + noPrefix)
+	return NewFullPath(string(fp), name)
 }
 
 // AsInode an in-memory only inode representation
@@ -78,9 +90,19 @@ func (fp FullPath) Split() []string {
 }
 
 func Join(names ...string) string {
-	return filepath.ToSlash(filepath.Join(names...))
+	newName := clearName(filepath.ToSlash(filepath.Join(names...)))
+	if newName != "/" && strings.HasSuffix(filepath.ToSlash(strings.Join(names, "")), "/") {
+		newName += "/"
+	}
+	return newName
 }
 
-func JoinPath(names ...string) FullPath {
-	return FullPath(Join(names...))
+func clearName(name string) string {
+	name = strings.ToValidUTF8(name, "?")
+	slashed := strings.HasSuffix(name, "/")
+	name = filepath.Clean(name)
+	if name != "/" && slashed {
+		name += "/"
+	}
+	return name
 }


### PR DESCRIPTION
I refactored `fullpath.go`. 
It supports:
1. Directory literal (ends with /) switch and detect. (no need to detect, add, remove `/` suffix directly anymore)
2. Replace invalid UTF-8 characters with `?`.
3. Handle `.` `..` and `//` in path.

Then refactored some codes related with `fullpath`.