### PR TITLE
it is safer to discard requests that have reached the concurrent limit

### DIFF
--- a/weed/server/volume_server_handlers.go
+++ b/weed/server/volume_server_handlers.go
@@ -1,6 +1,7 @@
 package weed_server
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -52,9 +53,11 @@ func (vs *VolumeServer) privateStoreHandler(w http.ResponseWriter, r *http.Reque
 		// wait until in flight data is less than the limit
 		contentLength := getContentLength(r)
 		vs.inFlightUploadDataLimitCond.L.Lock()
-		for vs.concurrentUploadLimit != 0 && atomic.LoadInt64(&vs.inFlightUploadDataSize) > vs.concurrentUploadLimit {
-			glog.V(4).Infof("wait because inflight upload data %d > %d", vs.inFlightUploadDataSize, vs.concurrentUploadLimit)
-			vs.inFlightUploadDataLimitCond.Wait()
+		if vs.concurrentUploadLimit != 0 && atomic.LoadInt64(&vs.inFlightUploadDataSize) > vs.concurrentUploadLimit {
+			err := fmt.Errorf("reject because inflight upload data %d > %d", vs.inFlightUploadDataSize, vs.concurrentUploadLimit)
+			glog.V(1).Infof(err.Error())
+			writeJsonError(w, r, http.StatusTooManyRequests, err)
+			return
 		}
 		vs.inFlightUploadDataLimitCond.L.Unlock()
 		atomic.AddInt64(&vs.inFlightUploadDataSize, contentLength)


### PR DESCRIPTION
https://github.com/chrislusf/seaweedfs/issues/2755