### PR TITLE
Add mTLS support for both master and volume http server.

### DIFF
--- a/weed/command/scaffold/security.toml
+++ b/weed/command/scaffold/security.toml
@@ -83,7 +83,13 @@ key = ""
 #     this does not work with other clients, e.g., "weed filer|mount" etc, yet.
 [https.client]
 enabled = true
+
 [https.volume]
 cert = ""
 key = ""
+ca = ""
 
+[https.master]
+cert = ""
+key = ""
+ca = ""


### PR DESCRIPTION
This adds TLS support to the master server, and mTLS support to both the master and volume server conditional on specifying the correct certificate files in security.toml.  If this is acceptable, I'm happy to also update the necessary documentation.