### PR TITLE
fix-filer: calculation error of the method skipCheckParentDirEntry

### DIFF
--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -131,7 +131,7 @@ func isAppend(r *http.Request) bool {
 }
 
 func skipCheckParentDirEntry(r *http.Request) bool {
-	return r.URL.Query().Get("skipCheckParentDir") != "true"
+	return r.URL.Query().Get("skipCheckParentDir") == "true"
 }
 
 func (fs *FilerServer) saveMetaData(ctx context.Context, r *http.Request, fileName string, contentType string, so *operation.StorageOption, md5bytes []byte, fileChunks []*filer_pb.FileChunk, chunkOffset int64, content []byte) (filerResult *FilerPostResult, replyerr error) {


### PR DESCRIPTION
fix: `curl -F file=@report.js "http://localhost:8888/javascript/some_file?skipCheckParentDir=true`