### PR TITLE
Add "Location:" in response when creating bucket

### DIFF
--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -135,6 +135,7 @@ func (s3a *S3ApiServer) PutBucketHandler(w http.ResponseWriter, r *http.Request)
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 		return
 	}
+	w.Header().Set("Location", "/" + bucket)
 	writeSuccessResponseEmpty(w, r)
 }
 


### PR DESCRIPTION
according to "https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html"

```
  HTTP/1.1 200 OK
  x-amz-id-2: YgIPIfBiKa2bj0KMg95r/0zo3emzU4dzsD4rcKCHQUAdQkf3ShJTOOpXUueF6QKo
  x-amz-request-id: 236A8905248E5A01
  Date: Wed, 01 Mar  2006 12:00:00 GMT

  Location: /colorpictures
  Content-Length: 0
  Connection: close
  Server: AmazonS3
 
```