### PR TITLE
chore(deps): Included dependency review

### DIFF
--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -1,0 +1,14 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@3f943b86c9a289f4e632c632695e2e0898d9d67d


### PR DESCRIPTION
> Dependency Review GitHub Action in your repository to enforce dependency reviews on your pull requests.
> The action scans for vulnerable versions of dependencies introduced by package version changes in pull requests,
> and warns you about the associated security vulnerabilities.
> This gives you better visibility of what's changing in a pull request,
> and helps prevent vulnerabilities being added to your repository.

https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
