### PR TITLE
fix return value

### DIFF
--- a/weed/shell/command_fs_configure.go
+++ b/weed/shell/command_fs_configure.go
@@ -62,7 +62,7 @@ func (c *commandFsConfigure) Do(args []string, commandEnv *CommandEnv, writer io
 	isDelete := fsConfigureCommand.Bool("delete", false, "delete the configuration by locationPrefix")
 	apply := fsConfigureCommand.Bool("apply", false, "update and apply filer configuration")
 	if err = fsConfigureCommand.Parse(args); err != nil {
-		return err
+		return nil
 	}
 
 	fc, err := filer.ReadFilerConf(commandEnv.option.FilerAddress, commandEnv.option.GrpcDialOption, commandEnv.MasterClient)

--- a/weed/shell/command_volume_vacuum.go
+++ b/weed/shell/command_volume_vacuum.go
@@ -34,7 +34,7 @@ func (c *commandVacuum) Do(args []string, commandEnv *CommandEnv, writer io.Writ
 	collection := volumeVacuumCommand.String("collection", "", "vacuum this collection")
 	volumeId := volumeVacuumCommand.Uint("volumeId", 0, "the volume id")
 	if err = volumeVacuumCommand.Parse(args); err != nil {
-		return
+		return nil
 	}
 
 	if err = commandEnv.confirmIsLocked(args); err != nil {


### PR DESCRIPTION
This PR corrects abnormal output with `volume.vacuum -h` and `fs.configure -h`.

For `volume.vacuum -h`, the PR changes its output from:
```
> volume.vacuum -h
Usage of volume.vacuum:
  -collection string
        vacuum this collection
  -garbageThreshold float
        vacuum when garbage is more than this limit (default 0.3)
  -volumeId uint
        the volume id
error: flag: help requested
```
to:
```
> volume.vacuum -h
Usage of volume.vacuum:
  -collection string
        vacuum this collection
  -garbageThreshold float
        vacuum when garbage is more than this limit (default 0.3)
  -volumeId uint
        the volume id
```

For `fs.configure -h`, the PR changes its output from:
```
> fs.configure -h
Usage of fs.configure:
  -apply
        update and apply filer configuration
  -collection string
        assign writes to this collection
  -dataCenter string
        assign writes to this dataCenter
  -dataNode string
        assign writes to this dataNode
  -delete
        delete the configuration by locationPrefix
  -disk string
        [hdd|ssd|<tag>] hard drive or solid state drive or any tag
  -fsync
        fsync for the writes
  -locationPrefix string
        path prefix, required to update the path-specific configuration
  -rack string
        assign writes to this rack
  -readOnly
        disable writes
  -replication string
        assign writes with this replication
  -ttl string
        assign writes with this ttl
  -volumeGrowthCount int
        the number of physical volumes to add if no writable volumes
error: flag: help requested
```
to 
```
> fs.configure -h
Usage of fs.configure:
  -apply
        update and apply filer configuration
  -collection string
        assign writes to this collection
  -dataCenter string
        assign writes to this dataCenter
  -dataNode string
        assign writes to this dataNode
  -delete
        delete the configuration by locationPrefix
  -disk string
        [hdd|ssd|<tag>] hard drive or solid state drive or any tag
  -fsync
        fsync for the writes
  -locationPrefix string
        path prefix, required to update the path-specific configuration
  -rack string
        assign writes to this rack
  -readOnly
        disable writes
  -replication string
        assign writes with this replication
  -ttl string
        assign writes with this ttl
  -volumeGrowthCount int
        the number of physical volumes to add if no writable volumes
```

Last but not least, the original abnormal output was caused by my previous PR #2683 and #2701. It's my fault and I feel terrible about that. Sorry. @chrislusf 