### PR TITLE
fix: sequence read rate is slow when use filer.ChunkReadAt.ReadAt

### DIFF
--- a/weed/filer/filechunk_manifest.go
+++ b/weed/filer/filechunk_manifest.go
@@ -2,6 +2,7 @@ package filer
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"github.com/chrislusf/seaweedfs/weed/wdclient"
 	"io"
@@ -115,7 +116,12 @@ func fetchWholeChunk(bytesBuffer *bytes.Buffer, lookupFileIdFn wdclient.LookupFi
 	return nil
 }
 
+var ErrNilFuncNotPermitted = errors.New("nil func is not permitted")
+
 func fetchChunkRange(buffer []byte, lookupFileIdFn wdclient.LookupFileIdFunctionType, fileId string, cipherKey []byte, isGzipped bool, offset int64) (int, error) {
+	if lookupFileIdFn == nil {
+		return 0, ErrNilFuncNotPermitted
+	}
 	urlStrings, err := lookupFileIdFn(fileId)
 	if err != nil {
 		glog.Errorf("operation LookupFileId %s failed, err: %v", fileId, err)

--- a/weed/filer/reader_at.go
+++ b/weed/filer/reader_at.go
@@ -98,10 +98,9 @@ func (c *ChunkReadAt) Close() error {
 
 func (c *ChunkReadAt) ReadAt(p []byte, offset int64) (n int, err error) {
 
-	c.readerPattern.MonitorReadAt(offset, len(p))
-
 	c.readerLock.Lock()
 	defer c.readerLock.Unlock()
+	c.readerPattern.MonitorReadAt(offset, len(p))
 
 	// glog.V(4).Infof("ReadAt [%d,%d) of total file size %d bytes %d chunk views", offset, offset+int64(len(p)), c.fileSize, len(c.chunkViews))
 	return c.doReadAt(p, offset)

--- a/weed/filer/reader_pattern.go
+++ b/weed/filer/reader_pattern.go
@@ -16,15 +16,17 @@ func NewReaderPattern() *ReaderPattern {
 }
 
 func (rp *ReaderPattern) MonitorReadAt(offset int64, size int) {
+	isStreaming := true
 	if rp.lastReadOffset > offset {
-		rp.isStreaming = false
+		isStreaming = false
 	}
 	if rp.lastReadOffset == -1 {
 		if offset != 0 {
-			rp.isStreaming = false
+			isStreaming = false
 		}
 	}
 	rp.lastReadOffset = offset
+	rp.isStreaming = isStreaming
 }
 
 func (rp *ReaderPattern) IsStreamingMode() bool {


### PR DESCRIPTION
### When I use mount fuse to test the io rate, I got a wired result. The reading sequence is very slow。#3069 
![Screenshot from 2022-05-17 16-14-11](https://user-images.githubusercontent.com/17705801/169012738-33b79adc-d3d9-4b43-810e-ef062ff03237.png)

### So i analyze some pprof of the weed mount program. Got this: 
![Screenshot from 2022-05-18 17-59-50](https://user-images.githubusercontent.com/17705801/169013521-dcfab7d9-01b5-4748-ab1d-8da4f36967e9.png)
![Screenshot from 2022-05-18 18-00-19](https://user-images.githubusercontent.com/17705801/169013533-18554196-1c2e-46b7-80c7-2b8003a469f2.png)

### Pull Request Description
  The filer.(*ChunkReadAt).ReadAt cost too much time, because every read request call the filer.fetchChunkRange. 

  I read the code of filer.(*ChunkReadAt).ReadAt, and found the reason is filer.ChunkReadAt.readerPattern.isStreaming was set to false, and can not be true forever. 

  That make the every fs.Read() make a ChunkRange request to volume server, so the read rate is very slow.

  Compare the read speed after this pull request:
![Screenshot from 2022-05-18 19-11-15](https://user-images.githubusercontent.com/17705801/169025875-1c1c261a-fe48-4f91-bd26-4b0bbd662c4a.png)

  And I use fio test the random read 4K, the performance is same as origin version weed.