### PR TITLE
feat: Send commands to weed shell from the docker image.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -57,6 +57,12 @@ case "$1" in
   	exec /usr/bin/weed -logtostderr=true s3 $ARGS $@
 	;;
 
+  'shell')
+  	ARGS="-cluster=$SHELL_CLUSTER -filer=$SHELL_FILER -filerGroup=$SHELL_FILER_GROUP -master=$SHELL_MASTER -options=$SHELL_OPTIONS"
+  	shift
+  	exec echo "$@" | /usr/bin/weed -logtostderr=true shell $ARGS
+  ;;
+
   *)
   	exec /usr/bin/weed $@
 	;;


### PR DESCRIPTION
Add the ability to send commands to weed shell from the docker image.

Allows an operator to perform maintenance commands like so:
```
docker run \
  --rm \
  -e SHELL_FILER=localhost:8888 \
  -e SHELL_MASTER=localhost:9333 \
  chrislusf/seaweedfs:local \
  "shell" \
  "fs.configure -locationPrefix=/buckets/foo -volumeGrowthCount=3 -replication=002 -apply"
```

# What problem are we solving?

`weed shell` commands aren't accessible from the Docker image currently, this PR adds support for this feature.

# How are we solving the problem?

Extend existing Docker entrypoints to include `weed shell`

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
