### PR TITLE
add disableXAttr in mount option

### DIFF
--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -30,6 +30,7 @@ type MountOptions struct {
 	debug              *bool
 	debugPort          *int
 	localSocket        *string
+	disableXAttr       *bool
 }
 
 var (
@@ -65,6 +66,7 @@ func init() {
 	mountOptions.debug = cmdMount.Flag.Bool("debug", false, "serves runtime profiling data, e.g., http://localhost:<debug.port>/debug/pprof/goroutine?debug=2")
 	mountOptions.debugPort = cmdMount.Flag.Int("debug.port", 6061, "http port for debugging")
 	mountOptions.localSocket = cmdMount.Flag.String("localSocket", "", "default to /tmp/seaweedfs-mount-<mount_dir_hash>.sock")
+	mountOptions.disableXAttr = cmdMount.Flag.Bool("disableXAttr", false, "disable xattr")
 
 	mountCpuProfile = cmdMount.Flag.String("cpuprofile", "", "cpu profile output file")
 	mountMemProfile = cmdMount.Flag.String("memprofile", "", "memory profile output file")

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -175,7 +175,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 		FsName:                   serverFriendlyName + ":" + filerMountRootPath,
 		Name:                     "seaweedfs",
 		SingleThreaded:           false,
-		DisableXAttrs:            false,
+		DisableXAttrs:            *option.disableXAttr,
 		Debug:                    *option.debug,
 		EnableLocks:              false,
 		ExplicitDataCacheControl: false,
@@ -238,6 +238,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 		VolumeServerAccess: *mountOptions.volumeServerAccess,
 		Cipher:             cipher,
 		UidGidMapper:       uidGidMapper,
+		DisableXAttr:       *option.disableXAttr,
 	})
 
 	server, err := fuse.NewServer(seaweedFileSystem, dir, fuseMountOptions)

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -40,6 +40,7 @@ type Option struct {
 	DataCenter         string
 	Umask              os.FileMode
 	Quota              int64
+	DisableXAttr       bool
 
 	MountUid         uint32
 	MountGid         uint32

--- a/weed/mount/weedfs_xattr.go
+++ b/weed/mount/weedfs_xattr.go
@@ -20,6 +20,10 @@ const (
 // with the required buffer size.
 func (wfs *WFS) GetXAttr(cancel <-chan struct{}, header *fuse.InHeader, attr string, dest []byte) (size uint32, code fuse.Status) {
 
+	if wfs.option.DisableXAttr {
+		return 0, fuse.Status(syscall.ENOTSUP)
+	}
+
 	//validate attr name
 	if len(attr) > MAX_XATTR_NAME_SIZE {
 		if runtime.GOOS == "darwin" {
@@ -69,6 +73,10 @@ func (wfs *WFS) GetXAttr(cancel <-chan struct{}, header *fuse.InHeader, attr str
 //              Perform a pure replace operation, which fails if the named
 //              attribute does not already exist.
 func (wfs *WFS) SetXAttr(cancel <-chan struct{}, input *fuse.SetXAttrIn, attr string, data []byte) fuse.Status {
+
+	if wfs.option.DisableXAttr {
+		return fuse.Status(syscall.ENOTSUP)
+	}
 
 	if wfs.IsOverQuota {
 		return fuse.Status(syscall.ENOSPC)
@@ -127,6 +135,11 @@ func (wfs *WFS) SetXAttr(cancel <-chan struct{}, input *fuse.SetXAttrIn, attr st
 // slice, and return the number of bytes. If the buffer is too
 // small, return ERANGE, with the required buffer size.
 func (wfs *WFS) ListXAttr(cancel <-chan struct{}, header *fuse.InHeader, dest []byte) (n uint32, code fuse.Status) {
+
+	if wfs.option.DisableXAttr {
+		return 0, fuse.Status(syscall.ENOTSUP)
+	}
+
 	_, _, entry, status := wfs.maybeReadEntry(header.NodeId)
 	if status != fuse.OK {
 		return 0, status
@@ -156,6 +169,11 @@ func (wfs *WFS) ListXAttr(cancel <-chan struct{}, header *fuse.InHeader, dest []
 
 // RemoveXAttr removes an extended attribute.
 func (wfs *WFS) RemoveXAttr(cancel <-chan struct{}, header *fuse.InHeader, attr string) fuse.Status {
+
+	if wfs.option.DisableXAttr {
+		return fuse.Status(syscall.ENOTSUP)
+	}
+
 	if len(attr) == 0 {
 		return fuse.EINVAL
 	}


### PR DESCRIPTION
# What problem are we solving?
In some user cases, we need use xattr(user define attr) to achive the logic, and we should disable user_attr to avoid user change it. cases include:
1. store  directory quota or other meta info in xattr 
2. store reference counting in xattr
3. user case don't need xattr

There is no place to disable xattr except change the source code and rebuild. I think this is a indispensable option.

# How are we solving the problem?
Add mount option to disable xattr.

# Checks
- [x] I have test it manualy, no unit test needed.
- [x] disableXAttr will be false as default, no caution for any user.
- [ ] I will add related wiki document changes and link to this PR after merging.
