### PR TITLE
perf: Bucket and collection decoupling

### DIFF
--- a/weed/shell/command_fs_configure.go
+++ b/weed/shell/command_fs_configure.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io"
-	"strings"
-
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
 	"github.com/chrislusf/seaweedfs/weed/storage/super_block"
+	"io"
 )
 
 func init() {
@@ -84,11 +82,6 @@ func (c *commandFsConfigure) Do(args []string, commandEnv *CommandEnv, writer io
 			DataCenter:        *dataCenter,
 			Rack:              *rack,
 			DataNode:          *dataNode,
-		}
-
-		// check collection
-		if *collection != "" && strings.HasPrefix(*locationPrefix, "/buckets/") {
-			return fmt.Errorf("one s3 bucket goes to one collection and not customizable")
 		}
 
 		// check replication


### PR DESCRIPTION
# What problem are we solving?

Collection is the way to organize volumeLayout, volumeLayout is a collection of volumes divided according to different ttl, diskType settings under a collection; different business scenarios will create different buckets,
In the current version, buckets and collections are strongly bound. The more buckets there are, the more collections there will be. When dealing with large-scale writes, there will be more scattered volumes, and the writes will become random writes, which will degrade performance. Configuring collection, the scattered writes of these buckets are written to the same volume, and random writes become sequential writes, which can greatly improve the writing speed, especially when writing large-scale small files.

In addition, the voLumes of different collections are isolated, and a volumeLayout cannot be shared by different buckets. If the actual data written to a bucket is only 1GB, but allocating 30GB will cause a waste of disk space;

This problem can be solved by configuring path matching rules through fs_configure, which can be very convenient for us to configure collection, dc, rack, ttl, etc. according to bucket as prefix, so in order for fs_configure to support this function, we need to delete this line of code

In the current version, the filer_write_handlers will match the filer rule config according to the requestURL. If the filer rule is not configured and the bucket is written, the collection name will be set to the bucket name. The filer rule has a higher priority than the bucket, so I think fs_configure can release the restriction , so that the collection to which the bucket belongs can be manually configured
