### PR TITLE
Bug Fix: force reload filer page when upload/delete/rename/create dir…

### DIFF
--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -225,6 +225,10 @@
         handleFiles(files);
     }
 
+    function reloadPage() {
+        window.location.reload(true);
+    }
+
     var uploadList = {};
 
     function handleFiles(files) {
@@ -277,7 +281,7 @@
         }
         if (allFinish) {
             console.log('All Finish');
-            window.location.reload();
+            reloadPage();
         }
     }
 
@@ -318,7 +322,7 @@
         xhr.open('POST', url, false);
         xhr.setRequestHeader('Content-Type', '');
         xhr.send();
-        window.location.reload();
+        reloadPage();
     }
 
     function handleRename(originName, basePath) {
@@ -333,7 +337,7 @@
         xhr.open('POST', url, false);
         xhr.setRequestHeader('Content-Type', '');
         xhr.send();
-        window.location.reload();
+        reloadPage();
     }
 
     function handleDelete(path) {
@@ -348,7 +352,7 @@
         var xhr = new XMLHttpRequest();
         xhr.open('DELETE', url, false);
         xhr.send();
-        window.location.reload();
+        reloadPage();
     }
 </script>
 </html>


### PR DESCRIPTION
…ectory

# What problem are we solving?

When upload file at filer UI finished, the refreshed page not show recently uploaded file. This PR will using force reload to prevent this issue.

# How are we solving the problem?

using `window.location.refresh(true)` to force page reload instead of using browser local cache.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
