### PR TITLE
fix: Anonymous access cannot be configured by deleting all permission…

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -137,9 +137,7 @@ func (iam *IdentityAccessManagement) loadS3ApiConfiguration(config *iam_pb.S3Api
 	iam.m.Lock()
 	// atomically switch
 	iam.identities = identities
-	if !iam.isAuthEnabled { // one-directional, no toggling
-		iam.isAuthEnabled = len(identities) > 0
-	}
+	iam.isAuthEnabled = len(identities) > 0
 	iam.m.Unlock()
 	return nil
 }


### PR DESCRIPTION
# What problem are we solving?

fix: Anonymous access cannot be configured by deleting all permissions, but anonymous access can be accessed after restarting, in this case "One-way, no switching" is broken

Sometimes it is convenient for testing such as test environments to enable anonymous access by removing all permissions, for example using JMeter

# How are we solving the problem?

Remove the if judgment so that when isAuthEnabled can be changed from true to false

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
