### PR TITLE
fix: When there is no access permission configured before startup, th…

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -176,12 +176,12 @@ func (iam *IdentityAccessManagement) lookupAnonymous() (identity *Identity, foun
 }
 
 func (iam *IdentityAccessManagement) Auth(f http.HandlerFunc, action Action) http.HandlerFunc {
-
-	if !iam.isEnabled() {
-		return f
-	}
-
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !iam.isEnabled() {
+			f(w, r)
+			return
+		}
+
 		identity, errCode := iam.authRequest(r, action)
 		if errCode == s3err.ErrNone {
 			if identity != nil && identity.Name != "" {


### PR DESCRIPTION
# What problem are we solving?

fix: When there is no access permission configured before startup, the authentication does not take effect after configuring the permission after startup

# How are we solving the problem?

Judge iam.isEnabled() on every request instead of at startup

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
