### PR TITLE
Add filer command line parameter to let Filer UI show/hide directory delete button

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -83,7 +83,7 @@ func init() {
 	f.debug = cmdFiler.Flag.Bool("debug", false, "serves runtime profiling data, e.g., http://localhost:<debug.port>/debug/pprof/goroutine?debug=2")
 	f.debugPort = cmdFiler.Flag.Int("debug.port", 6060, "http port for debugging")
 	f.localSocket = cmdFiler.Flag.String("localSocket", "", "default to /tmp/seaweedfs-filer-<port>.sock")
-	f.showUIDirectoryDelete = cmdFiler.Flag.Bool("ui.deleteDir", false, "enable filer UI show delete directory button")
+	f.showUIDirectoryDelete = cmdFiler.Flag.Bool("ui.deleteDir", true, "enable filer UI show delete directory button")
 
 	// start s3 on filer
 	filerStartS3 = cmdFiler.Flag.Bool("s3", false, "whether to start S3 gateway")

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -55,6 +55,7 @@ type FilerOptions struct {
 	debug                   *bool
 	debugPort               *int
 	localSocket             *string
+	showUIDirectoryDelete   *bool
 }
 
 func init() {
@@ -82,6 +83,7 @@ func init() {
 	f.debug = cmdFiler.Flag.Bool("debug", false, "serves runtime profiling data, e.g., http://localhost:<debug.port>/debug/pprof/goroutine?debug=2")
 	f.debugPort = cmdFiler.Flag.Int("debug.port", 6060, "http port for debugging")
 	f.localSocket = cmdFiler.Flag.String("localSocket", "", "default to /tmp/seaweedfs-filer-<port>.sock")
+	f.showUIDirectoryDelete = cmdFiler.Flag.Bool("ui.deleteDir", false, "enable filer UI show delete directory button")
 
 	// start s3 on filer
 	filerStartS3 = cmdFiler.Flag.Bool("s3", false, "whether to start S3 gateway")
@@ -216,6 +218,7 @@ func (fo *FilerOptions) startFiler() {
 		Cipher:                *fo.cipher,
 		SaveToFilerLimit:      int64(*fo.saveToFilerLimit),
 		ConcurrentUploadLimit: int64(*fo.concurrentUploadLimitMB) * 1024 * 1024,
+		ShowUIDirectoryDelete: *fo.showUIDirectoryDelete,
 	})
 	if nfs_err != nil {
 		glog.Fatalf("Filer startup error: %v", nfs_err)

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -2,8 +2,6 @@ package command
 
 import (
 	"fmt"
-	"github.com/chrislusf/seaweedfs/weed/pb"
-	"github.com/chrislusf/seaweedfs/weed/util/grace"
 	"net/http"
 	"os"
 	"strings"
@@ -12,7 +10,9 @@ import (
 	stats_collect "github.com/chrislusf/seaweedfs/weed/stats"
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
+	"github.com/chrislusf/seaweedfs/weed/pb"
 	"github.com/chrislusf/seaweedfs/weed/util"
+	"github.com/chrislusf/seaweedfs/weed/util/grace"
 )
 
 type ServerOptions struct {
@@ -114,6 +114,7 @@ func init() {
 	filerOptions.saveToFilerLimit = cmdServer.Flag.Int("filer.saveToFilerLimit", 0, "Small files smaller than this limit can be cached in filer store.")
 	filerOptions.concurrentUploadLimitMB = cmdServer.Flag.Int("filer.concurrentUploadLimitMB", 64, "limit total concurrent upload size")
 	filerOptions.localSocket = cmdServer.Flag.String("filer.localSocket", "", "default to /tmp/seaweedfs-filer-<port>.sock")
+	filerOptions.showUIDirectoryDelete = cmdServer.Flag.Bool("filer.ui.deleteDir", true, "enable filer UI show delete directory button")
 
 	serverOptions.v.port = cmdServer.Flag.Int("volume.port", 8080, "volume server http listen port")
 	serverOptions.v.portGrpc = cmdServer.Flag.Int("volume.port.grpc", 0, "volume server grpc listen port")

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -3,7 +3,6 @@ package weed_server
 import (
 	"context"
 	"fmt"
-	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
 	"net/http"
 	"os"
 	"sync"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/chrislusf/seaweedfs/weed/operation"
 	"github.com/chrislusf/seaweedfs/weed/pb"
+	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
 	"github.com/chrislusf/seaweedfs/weed/pb/master_pb"
 	"github.com/chrislusf/seaweedfs/weed/util"
 
@@ -67,6 +67,7 @@ type FilerOption struct {
 	Cipher                bool
 	SaveToFilerLimit      int64
 	ConcurrentUploadLimit int64
+	ShowUIDirectoryDelete bool
 }
 
 type FilerServer struct {

--- a/weed/server/filer_server_handlers_read_dir.go
+++ b/weed/server/filer_server_handlers_read_dir.go
@@ -73,7 +73,7 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	ui.StatusTpl.Execute(w, struct {
+	err = ui.StatusTpl.Execute(w, struct {
 		Path                  string
 		Breadcrumbs           []ui.Breadcrumb
 		Entries               interface{}
@@ -81,6 +81,7 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 		LastFileName          string
 		ShouldDisplayLoadMore bool
 		EmptyFolder           bool
+		ShowDirectoryDelete   bool
 	}{
 		path,
 		ui.ToBreadcrumb(path),
@@ -89,5 +90,9 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 		lastFileName,
 		shouldDisplayLoadMore,
 		emptyFolder,
+		fs.option.ShowUIDirectoryDelete,
 	})
+	if err != nil {
+		glog.V(0).Infof("Template Execute Error: %v", err)
+	}
 }

--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -109,38 +109,37 @@
         <form class="upload-form">
             <input type="file" id="fileElem" multiple onchange="handleFiles(this.files)">
 
-            {{if .EmptyFolder}}
+            {{ if .EmptyFolder }}
             <div class="row add-files">
                 +
             </div>
-            {{else}}
+            {{ else }}
             <table width="100%" class="table table-hover">
-                {{$path := .Path }}
+                {{ $path := .Path }}
+                {{ $showDirDel := .ShowDirectoryDelete }}
                 {{ range $entry_index, $entry := .Entries }}
                 <tr>
                     <td>
-                        {{if $entry.IsDirectory}}
+                        {{ if $entry.IsDirectory }}
                         <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>&nbsp;
                         <a href="{{ printpath $path  "/" $entry.Name "/"}}" >
                         {{ $entry.Name }}
                         </a>
-                        {{else}}
+                        {{ else }}
                         <a href="{{ printpath $path  "/" $entry.Name }}" >
                         {{ $entry.Name }}
                         </a>
-                        {{end}}
+                        {{ end }}
                     </td>
                     <td align="right" nowrap>
-                        {{if $entry.IsDirectory}}
-                        {{else}}
+                        {{ if not $entry.IsDirectory }}
                         {{ $entry.Mime }}&nbsp;
-                        {{end}}
+                        {{ end }}
                     </td>
                     <td align="right" nowrap>
-                        {{if $entry.IsDirectory}}
-                        {{else}}
+                        {{ if not $entry.IsDirectory }}
                         {{ $entry.Size | humanizeBytes }}&nbsp;
-                        {{end}}
+                        {{ end }}
                     </td>
                     <td align="right" nowrap>
                         {{ $entry.Timestamp.Format "2006-01-02 15:04" }}
@@ -150,31 +149,32 @@
                             <label class="btn" onclick="handleRename('{{ $entry.Name }}', '{{ printpath $path "/" }}')">
                                 <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
                             </label>
-                            {{if $entry.IsDirectory}}
-                            <label class="btn" onclick="handleDelete('{{ printpath $path  "/" $entry.Name "/"  }}')">
+                            {{ if and $entry.IsDirectory $showDirDel }}
+                            <label class="btn" onclick="handleDelete('{{ printpath $path  "/" $entry.Name "/" }}')">
                                 <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                             </label>
-                            {{else}}
+                            {{ end }}
+                            {{ if not $entry.IsDirectory }}
                             <label class="btn" onclick="handleDelete('{{ printpath $path  "/" $entry.Name }}')">
                                 <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                             </label>
-                            {{end}}
+                            {{ end }}
                         </div>
                     </td>
                 </tr>
                 {{ end }}
             </table>
-            {{end}}
+            {{ end }}
         </form>
     </div>
 
-    {{if .ShouldDisplayLoadMore}}
+    {{ if .ShouldDisplayLoadMore }}
     <div class="row">
-        <a href={{ print .Path "?limit=" .Limit "&lastFileName=" .LastFileName}} >
+        <a href={{ print .Path "?limit=" .Limit "&lastFileName=" .LastFileName }} >
         Load more
         </a>
     </div>
-    {{end}}
+    {{ end }}
 
     <br/>
     <br/>


### PR DESCRIPTION
# What problem are we solving?

As #3149 mentioned, show delete directory button is danger. This PR will provide a filer command line parameter to let end user control the delete button show or not. 

# How are we solving the problem?

Provide `-ui.deleteDir` parameter for filer to control filer UI show or hide the delete button for directory. Default is true so if user want to disable delete directory button just add `-ui.deleteDir=false` parameter when start filer server.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
