### PR TITLE
remove "weed" from UsageLine, or weed will not show usage of weed update

### DIFF
--- a/weed/command/update.go
+++ b/weed/command/update.go
@@ -75,7 +75,7 @@ func init() {
 }
 
 var cmdUpdate = &Command{
-	UsageLine: "weed update -dir=/path/to/dir -name=name -version=x.xx",
+	UsageLine: "update [-dir=/path/to/dir] [-name=name] [-version=x.xx]",
 	Short:     "get latest or specific version from https://github.com/chrislusf/seaweedfs",
 	Long:      `get latest or specific version from https://github.com/chrislusf/seaweedfs`,
 }


### PR DESCRIPTION
# What problem are we solving?
remove "weed" from UsageLine, or weed will not show usage of weed update


# How are we solving the problem?

remove "weed" from UsageLine
# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
