### PR TITLE
force close gRPC client closed connections

### DIFF
--- a/weed/pb/grpc_client_server.go
+++ b/weed/pb/grpc_client_server.go
@@ -144,6 +144,12 @@ func WithGrpcClient(streamingMode bool, fn func(*grpc.ClientConn) error, address
 		defer grpcConnection.Close()
 		executionErr := fn(grpcConnection)
 		if executionErr != nil {
+			// Try force close closed client connection https://github.com/chrislusf/seaweedfs/issues/2802
+			if strings.Contains(executionErr.Error(), "connection closed") {
+				if err := grpcConnection.Close(); err != nil {
+					glog.Warningf("grpc client close error: %v", err)
+				}
+			}
 			return executionErr
 		}
 		return nil


### PR DESCRIPTION
https://github.com/chrislusf/seaweedfs/issues/2802

# What problem are we solving?

https://github.com/chrislusf/seaweedfs/issues/2802

# How are we solving the problem?

We are trying to close the permanently closed gRPC client connection

# Checks
- [ok] I have added unit tests if possible.
- [ok] I will add related wiki document changes and link to this PR after merging.
