### PR TITLE
fix: the full url's format of LookupFileIdWithFallback

### DIFF
--- a/weed/wdclient/vid_map.go
+++ b/weed/wdclient/vid_map.go
@@ -90,6 +90,10 @@ func (vc *vidMap) LookupVolumeServerUrl(vid string) (serverUrls []string, err er
 	return
 }
 
+func (vc *vidMap) BuildFullUrl(serverUrl, fileId string) string {
+	return "http://" + serverUrl + "/" + fileId
+}
+
 func (vc *vidMap) LookupFileId(fileId string) (fullUrls []string, err error) {
 	parts := strings.Split(fileId, ",")
 	if len(parts) != 2 {
@@ -100,7 +104,7 @@ func (vc *vidMap) LookupFileId(fileId string) (fullUrls []string, err error) {
 		return nil, lookupError
 	}
 	for _, serverUrl := range serverUrls {
-		fullUrls = append(fullUrls, "http://"+serverUrl+"/"+fileId)
+		fullUrls = append(fullUrls, vc.BuildFullUrl(serverUrl, fileId))
 	}
 	return
 }


### PR DESCRIPTION
# What problem are we solving?
1. `filer` server’s error log..
`filer_server_handlers_read.go:244] failed to stream content /osss3/tests3/download-172.25.82.13-1MB-navkjx8wp7-3245845: read chunk: parse "172.24.66.21:32576?readDeleted=true": first path segment in URL cannot contain colon`

2. full url did not deduplicate
3. No need to update `vidmap` every `get` request time

