### PR TITLE
fix: retry to wait rebuild vidmap when grpc connection has closed.

### DIFF
--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -43,6 +43,7 @@ func (mc *MasterClient) GetLookupFileIdFunction() LookupFileIdFunctionType {
 }
 
 func (mc *MasterClient) LookupFileIdWithFallback(fileId string) (fullUrls []string, err error) {
+	fullUrls, err = mc.vidMap.LookupFileId(fileId)
 	err = pb.WithMasterClient(false, mc.currentMaster, mc.grpcDialOption, func(client master_pb.SeaweedClient) error {
 		resp, err := client.LookupVolume(context.Background(), &master_pb.LookupVolumeRequest{
 			VolumeOrFileIds: []string{fileId},
@@ -50,18 +51,20 @@ func (mc *MasterClient) LookupFileIdWithFallback(fileId string) (fullUrls []stri
 		if err != nil {
 			return err
 		}
-		for _, vidLocation := range resp.VolumeIdLocations {
+		for vid, vidLocation := range resp.VolumeIdLocations {
 			for _, vidLoc := range vidLocation.Locations {
-				fullUrls = append(fullUrls, mc.vidMap.BuildFullUrl(vidLoc.Url, fileId))
+				loc := Location{
+					Url:       vidLoc.Url,
+					PublicUrl: vidLoc.PublicUrl,
+					GrpcPort:  int(vidLoc.GrpcPort),
+				}
+				mc.vidMap.addLocation(uint32(vid), loc)
+				fullUrls = append(fullUrls, loc.Url)
 			}
 		}
 
 		return nil
 	})
-
-	if err != nil {
-		fullUrls, err = mc.vidMap.LookupFileId(fileId)
-	}
 	return
 }
 

--- a/weed/wdclient/vid_map.go
+++ b/weed/wdclient/vid_map.go
@@ -90,10 +90,6 @@ func (vc *vidMap) LookupVolumeServerUrl(vid string) (serverUrls []string, err er
 	return
 }
 
-func (vc *vidMap) BuildFullUrl(serverUrl, fileId string) string {
-	return "http://" + serverUrl + "/" + fileId
-}
-
 func (vc *vidMap) LookupFileId(fileId string) (fullUrls []string, err error) {
 	parts := strings.Split(fileId, ",")
 	if len(parts) != 2 {
@@ -104,7 +100,7 @@ func (vc *vidMap) LookupFileId(fileId string) (fullUrls []string, err error) {
 		return nil, lookupError
 	}
 	for _, serverUrl := range serverUrls {
-		fullUrls = append(fullUrls, vc.BuildFullUrl(serverUrl, fileId))
+		fullUrls = append(fullUrls, "http://"+serverUrl+"/"+fileId)
 	}
 	return
 }

--- a/weed/wdclient/vid_map.go
+++ b/weed/wdclient/vid_map.go
@@ -90,6 +90,10 @@ func (vc *vidMap) LookupVolumeServerUrl(vid string) (serverUrls []string, err er
 	return
 }
 
+func (vc *vidMap) BuildFullUrl(serverUrl, fileId string) string {
+	return "http://" + serverUrl + "/" + fileId
+}
+
 func (vc *vidMap) LookupFileId(fileId string) (fullUrls []string, err error) {
 	parts := strings.Split(fileId, ",")
 	if len(parts) != 2 {
@@ -100,7 +104,7 @@ func (vc *vidMap) LookupFileId(fileId string) (fullUrls []string, err error) {
 		return nil, lookupError
 	}
 	for _, serverUrl := range serverUrls {
-		fullUrls = append(fullUrls, "http://"+serverUrl+"/"+fileId)
+		fullUrls = append(fullUrls, vc.BuildFullUrl(serverUrl, fileId))
 	}
 	return
 }


### PR DESCRIPTION
# What problem are we solving?
[commit]( https://github.com/chrislusf/seaweedfs/commit/9c517d2b358da00c6d8fe638eaa6e8551c65aa8d) has some problems.
1. full url did not deduplicate
2. `filer` server’s error log..
`filer_server_handlers_read.go:244] failed to stream content /osss3/tests3/download-172.25.82.13-1MB-navkjx8wp7-3245845: read chunk: parse "172.24.66.21:32576?readDeleted=true": first path segment in URL cannot contain colon`
3. when grpc connection has closed, `vidmap`  and `mc.currentMaster` all empty,so `pb.WithMasterClient(false, mc.currentMaster, mc.grpcDialOption, func(client master_pb.SeaweedClient) `  also return error.


# How are we solving the problem?

retry most 5 times to wait rebuild `vidmap`