### PR TITLE
feat(filer.sync): add parallel synchronization function

### DIFF
--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -22,27 +22,32 @@ import (
 )
 
 type SyncOptions struct {
-	isActivePassive *bool
-	filerA          *string
-	filerB          *string
-	aPath           *string
-	bPath           *string
-	aReplication    *string
-	bReplication    *string
-	aCollection     *string
-	bCollection     *string
-	aTtlSec         *int
-	bTtlSec         *int
-	aDiskType       *string
-	bDiskType       *string
-	aDebug          *bool
-	bDebug          *bool
-	aFromTsMs       *int64
-	bFromTsMs       *int64
-	aProxyByFiler   *bool
-	bProxyByFiler   *bool
-	metricsHttpPort *int
-	clientId        int32
+	isActivePassive     *bool
+	filerA              *string
+	filerB              *string
+	aPath               *string
+	bPath               *string
+	aReplication        *string
+	bReplication        *string
+	aCollection         *string
+	bCollection         *string
+	aTtlSec             *int
+	bTtlSec             *int
+	aDiskType           *string
+	bDiskType           *string
+	aDebug              *bool
+	bDebug              *bool
+	aFromTsMs           *int64
+	bFromTsMs           *int64
+	aProxyByFiler       *bool
+	bProxyByFiler       *bool
+	aParallelNum        *int
+	bParallelNum        *int
+	aParallelBatchSize  *int64
+	bParallelBatchSize  *int64
+	parallelMaxInterval *string
+	metricsHttpPort     *int
+	clientId            int32
 }
 
 var (
@@ -72,6 +77,11 @@ func init() {
 	syncOptions.bDebug = cmdFilerSynchronize.Flag.Bool("b.debug", false, "debug mode to print out filer B received files")
 	syncOptions.aFromTsMs = cmdFilerSynchronize.Flag.Int64("a.fromTsMs", 0, "synchronization from timestamp on filer A. The unit is millisecond")
 	syncOptions.bFromTsMs = cmdFilerSynchronize.Flag.Int64("b.fromTsMs", 0, "synchronization from timestamp on filer B. The unit is millisecond")
+	syncOptions.aParallelNum = cmdFilerSynchronize.Flag.Int("a.parallelNum", 1, "a -> b, the number of synchronization parallel task. range 1 to 255")
+	syncOptions.bParallelNum = cmdFilerSynchronize.Flag.Int("b.parallelNum", 1, "b -> a, the number of synchronization parallel task. range 1 to 255")
+	syncOptions.aParallelBatchSize = cmdFilerSynchronize.Flag.Int64("a.parallelBatchSize", 500, "a -> b, The amount of one-time processing for a single parallel task")
+	syncOptions.bParallelBatchSize = cmdFilerSynchronize.Flag.Int64("b.parallelBatchSize", 500, "b -> a, The amount of one-time processing for a single parallel task")
+	syncOptions.parallelMaxInterval = cmdFilerSynchronize.Flag.String("parallelMaxInterval", "3s", "Maximum synchronization interval. At the same level as parallelBatchSize")
 	syncCpuProfile = cmdFilerSynchronize.Flag.String("cpuprofile", "", "cpu profile output file")
 	syncMemProfile = cmdFilerSynchronize.Flag.String("memprofile", "", "memory profile output file")
 	syncOptions.metricsHttpPort = cmdFilerSynchronize.Flag.Int("metricsPort", 0, "metrics listen port")
@@ -121,7 +131,11 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 		glog.Errorf("get filer 'b' signature %d error from %s to %s: %v", bFilerSignature, *syncOptions.filerA, *syncOptions.filerB, bFilerErr)
 		return true
 	}
-
+	parallelMaxInterval, parseIntervalErr := time.ParseDuration(*syncOptions.parallelMaxInterval)
+	if parseIntervalErr != nil {
+		glog.Errorf("the parallelMaxInterval format is error. %v", parseIntervalErr)
+		return true
+	}
 	go func() {
 		// a->b
 		// set synchronization start timestamp to offset
@@ -133,7 +147,7 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 		for {
 			err := doSubscribeFilerMetaChanges(syncOptions.clientId, grpcDialOption, filerA, *syncOptions.aPath, *syncOptions.aProxyByFiler, filerB,
 				*syncOptions.bPath, *syncOptions.bReplication, *syncOptions.bCollection, *syncOptions.bTtlSec, *syncOptions.bProxyByFiler, *syncOptions.bDiskType,
-				*syncOptions.bDebug, aFilerSignature, bFilerSignature)
+				*syncOptions.bDebug, aFilerSignature, bFilerSignature, *syncOptions.aParallelNum, *syncOptions.aParallelBatchSize, parallelMaxInterval)
 			if err != nil {
 				glog.Errorf("sync from %s to %s: %v", *syncOptions.filerA, *syncOptions.filerB, err)
 				time.Sleep(1747 * time.Millisecond)
@@ -153,7 +167,7 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 			for {
 				err := doSubscribeFilerMetaChanges(syncOptions.clientId, grpcDialOption, filerB, *syncOptions.bPath, *syncOptions.bProxyByFiler, filerA,
 					*syncOptions.aPath, *syncOptions.aReplication, *syncOptions.aCollection, *syncOptions.aTtlSec, *syncOptions.aProxyByFiler, *syncOptions.aDiskType,
-					*syncOptions.aDebug, bFilerSignature, aFilerSignature)
+					*syncOptions.aDebug, bFilerSignature, aFilerSignature, *syncOptions.bParallelNum, *syncOptions.bParallelBatchSize, parallelMaxInterval)
 				if err != nil {
 					glog.Errorf("sync from %s to %s: %v", *syncOptions.filerB, *syncOptions.filerA, err)
 					time.Sleep(2147 * time.Millisecond)
@@ -184,7 +198,7 @@ func initOffsetFromTsMs(grpcDialOption grpc.DialOption, targetFiler pb.ServerAdd
 }
 
 func doSubscribeFilerMetaChanges(clientId int32, grpcDialOption grpc.DialOption, sourceFiler pb.ServerAddress, sourcePath string, sourceReadChunkFromFiler bool, targetFiler pb.ServerAddress, targetPath string,
-	replicationStr, collection string, ttlSec int, sinkWriteChunkByFiler bool, diskType string, debug bool, sourceFilerSignature int32, targetFilerSignature int32) error {
+	replicationStr, collection string, ttlSec int, sinkWriteChunkByFiler bool, diskType string, debug bool, sourceFilerSignature int32, targetFilerSignature int32, parallelNum int, parallelBatchSize int64, parallelMaxInterval time.Duration) error {
 
 	// if first time, start from now
 	// if has previously synced, resume from that point of time
@@ -198,33 +212,70 @@ func doSubscribeFilerMetaChanges(clientId int32, grpcDialOption grpc.DialOption,
 	// create filer sink
 	filerSource := &source.FilerSource{}
 	filerSource.DoInitialize(sourceFiler.ToHttpAddress(), sourceFiler.ToGrpcAddress(), sourcePath, sourceReadChunkFromFiler)
-	filerSink := &filersink.FilerSink{}
-	filerSink.DoInitialize(targetFiler.ToHttpAddress(), targetFiler.ToGrpcAddress(), targetPath, replicationStr, collection, ttlSec, diskType, grpcDialOption, sinkWriteChunkByFiler)
-	filerSink.SetSourceFiler(filerSource)
 
-	persistEventFn := genProcessFunction(sourcePath, targetPath, filerSink, debug)
-
-	processEventFn := func(resp *filer_pb.SubscribeMetadataResponse) error {
-		message := resp.EventNotification
-		for _, sig := range message.Signatures {
-			if sig == targetFilerSignature && targetFilerSignature != 0 {
-				fmt.Printf("%s skipping %s change to %v\n", targetFiler, sourceFiler, message)
-				return nil
-			}
-		}
-		return persistEventFn(resp)
-	}
-
-	var lastLogTsNs = time.Now().Nanosecond()
+	var lastLogTsNs = time.Now().UnixNano()
 	var clientName = fmt.Sprintf("syncFrom_%s_To_%s", string(sourceFiler), string(targetFiler))
-	processEventFnWithOffset := pb.AddOffsetFunc(processEventFn, 3*time.Second, func(counter int64, lastTsNs int64) error {
-		now := time.Now().Nanosecond()
-		glog.V(0).Infof("sync %s to %s progressed to %v %0.2f/sec", sourceFiler, targetFiler, time.Unix(0, lastTsNs), float64(counter)/(float64(now-lastLogTsNs)/1e9))
+	var processEventFnWithOffset pb.ProcessMetadataFunc
+
+	setOffsetFunc := func(counter int64, lastTsNs int64) error {
+		now := time.Now().UnixNano()
+		glog.V(0).Infof("sync %s to %s progressed to %v %0.2f/sec.", sourceFiler, targetFiler, time.Unix(0, lastTsNs), float64(counter)/(float64(now-lastLogTsNs)/1e9))
 		lastLogTsNs = now
 		// collect synchronous offset
 		statsCollect.FilerSyncOffsetGauge.WithLabelValues(sourceFiler.String(), targetFiler.String(), clientName, sourcePath).Set(float64(lastTsNs))
 		return setOffset(grpcDialOption, targetFiler, getSignaturePrefixByPath(sourcePath), sourceFilerSignature, lastTsNs)
-	})
+	}
+
+	if parallelNum <= 1 {
+		filerSink := &filersink.FilerSink{}
+		filerSink.DoInitialize(targetFiler.ToHttpAddress(), targetFiler.ToGrpcAddress(), targetPath, replicationStr, collection, ttlSec, diskType, grpcDialOption, sinkWriteChunkByFiler)
+		filerSink.SetSourceFiler(filerSource)
+		persistEventFn := genProcessFunction(sourcePath, targetPath, filerSink, debug)
+
+		processEventFn := func(resp *filer_pb.SubscribeMetadataResponse) error {
+			message := resp.EventNotification
+			for _, sig := range message.Signatures {
+				if sig == targetFilerSignature && targetFilerSignature != 0 {
+					fmt.Printf("%s skipping %s change to %v\n", targetFiler, sourceFiler, message)
+					return nil
+				}
+			}
+			return persistEventFn(resp)
+		}
+		processEventFnWithOffset = pb.AddOffsetFunc(processEventFn, 3*time.Second, setOffsetFunc)
+	} else {
+		glog.Infof("parallel synchronization started. parallelNum:%d, parallelMaxInterval:%s. from %s to %s. ", parallelNum, parallelMaxInterval.String(), sourceFiler.String(), targetFiler.String())
+		//  a semaphore for stopping the trigger
+		parallelSyncCancel := make(chan struct{})
+		defer func() {
+			parallelSyncCancel <- struct{}{}
+			glog.Infof("parallel synchronization exit. from %s to %s", sourceFiler.String(), targetFiler.String())
+		}()
+
+		// worker filerSink
+		var persistEventFns []func(resp *filer_pb.SubscribeMetadataResponse) error
+		for i := 0; i < parallelNum; i++ {
+			filerSinkItem := &filersink.FilerSink{}
+			filerSinkItem.DoInitialize(targetFiler.ToHttpAddress(), targetFiler.ToGrpcAddress(), targetPath, replicationStr, collection, ttlSec, diskType, grpcDialOption, sinkWriteChunkByFiler)
+			filerSinkItem.SetSourceFiler(filerSource)
+			persistEventFn := genProcessFunction(sourcePath, targetPath, filerSinkItem, debug)
+			persistEventFns = append(persistEventFns, persistEventFn)
+		}
+
+		c := ParallelSyncMetadataCache{persistEventFns: persistEventFns, l: []*filer_pb.SubscribeMetadataResponse{}, ParallelNum: parallelNum,
+			ParallelBatchSize: parallelBatchSize, sourceFiler: sourceFiler.String(), targetFiler: targetFiler.String()}
+
+		// parameter range limit
+		if c.ParallelNum < 1 {
+			c.ParallelNum = 1
+		} else if uint8(c.ParallelNum) > ^uint8(0) {
+			c.ParallelNum = 255
+		}
+
+		runParallelSyncScheduledTask(&c, parallelSyncCancel, parallelMaxInterval, setOffsetFunc)
+
+		processEventFnWithOffset = getProcessEventFnWithOffsetFunc(&c, sourceFiler, targetFiler, targetFilerSignature, setOffsetFunc)
+	}
 
 	return pb.FollowMetadata(sourceFiler, grpcDialOption, clientName, clientId,
 		sourcePath, nil, sourceFilerOffsetTsNs, 0, targetFilerSignature, processEventFnWithOffset, pb.RetryForeverOnError)

--- a/weed/command/filer_sync_parallel.go
+++ b/weed/command/filer_sync_parallel.go
@@ -1,0 +1,282 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/chrislusf/seaweedfs/weed/glog"
+	"github.com/chrislusf/seaweedfs/weed/pb"
+	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
+	"github.com/chrislusf/seaweedfs/weed/util"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ParallelSyncMetadataCache struct {
+	lock              sync.RWMutex
+	l                 []*filer_pb.SubscribeMetadataResponse
+	ParallelNum       int
+	ParallelBatchSize int64
+	lastTime          int64
+	TsNs              int64
+	sourceFiler       string
+	targetFiler       string
+	persistEventFns   []func(resp *filer_pb.SubscribeMetadataResponse) error
+}
+
+type ParallelSyncNode struct {
+	key      string
+	value    []int
+	path     string
+	fullPath []string
+	child    []*ParallelSyncNode
+}
+
+func getProcessEventFnWithOffsetFunc(c *ParallelSyncMetadataCache, sourceFiler pb.ServerAddress, targetFiler pb.ServerAddress, targetFilerSignature int32,
+	setOffsetFunc func(counter int64, lastTsNs int64) error) pb.ProcessMetadataFunc {
+	return pb.AddOffsetParallelSyncFunc(func(resp *filer_pb.SubscribeMetadataResponse) (error, int64) {
+		message := resp.EventNotification
+		for _, sig := range message.Signatures {
+			if sig == targetFilerSignature && targetFilerSignature != 0 {
+				fmt.Printf("%s skipping %s change to %v\n", targetFiler, sourceFiler, message)
+				return nil, 1
+			}
+		}
+		return persistEventParallelSyncFunc(c, resp)
+	}, 3*time.Second, setOffsetFunc)
+}
+
+var runParallelSyncScheduledTask = func(cache *ParallelSyncMetadataCache, stop chan struct{}, d time.Duration, setOffsetFunc func(counter int64, lastTsNs int64) error) {
+	go func(c *ParallelSyncMetadataCache) {
+		for range time.Tick(d) {
+			select {
+			case <-stop:
+				close(stop)
+				return
+			default:
+				if len(c.l) > 0 && time.Since(time.UnixMilli(c.lastTime)) >= d {
+					counter := doPersistEventParallel(c)
+					// it's not necessary to set offset successfully. Just wait until next time.
+					_ = setOffsetFunc(counter, c.TsNs)
+				}
+			}
+		}
+	}(cache)
+}
+
+func persistEventParallelSyncFunc(c *ParallelSyncMetadataCache, resp *filer_pb.SubscribeMetadataResponse) (error, int64) {
+	// Scheduled tasks may trigger empty operation, which needs to be locked
+	c.lock.Lock()
+	c.l = append(c.l, resp)
+	c.TsNs = resp.TsNs
+	sendSize := int64(len(c.l))
+	c.lock.Unlock()
+	if sendSize < c.ParallelBatchSize {
+		return nil, 0
+	}
+	doPersistEventParallel(c)
+	return nil, sendSize
+}
+
+// doPersistEventParallel For parallel persistence of metadata
+func doPersistEventParallel(c *ParallelSyncMetadataCache) int64 {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.lastTime = time.Now().UnixMilli()
+	var finishTime = time.Now()
+	syncLength := len(c.l)
+	if syncLength == 0 {
+		return 0
+	}
+
+	// need to wait for all the split results to be processed
+	wg := sync.WaitGroup{}
+	wg.Add(c.ParallelNum)
+	// assign tasks to each worker thread
+	sendGroup := splitMetadataResponseByPath(c.ParallelNum, c.l)
+	for i := 0; i < c.ParallelNum; i++ {
+		go func(data []*filer_pb.SubscribeMetadataResponse, idx int, c *ParallelSyncMetadataCache) {
+			defer wg.Done()
+			for _, eventMsg := range data {
+				err := c.persistEventFns[idx](eventMsg)
+				if err != nil {
+					util.RetryForever("parallelSyncMeta", func() error {
+						return c.persistEventFns[idx](eventMsg)
+					}, func(err error) bool {
+						glog.Errorf("parallel sync process %v: %v", eventMsg, err)
+						return true
+					})
+				}
+			}
+		}(sendGroup[i], i, c)
+	}
+	wg.Wait()
+	c.l = c.l[:0]
+
+	glog.Infof("parallel sync %s to %s, cost: %dms, worker:%d send size:%d", c.sourceFiler, c.targetFiler, time.Since(finishTime).Milliseconds(), c.ParallelNum, syncLength)
+
+	return int64(syncLength)
+}
+
+// splitMetadataResponseByPath Split MetadataResponse to array. The result is not affect the processing order.
+func splitMetadataResponseByPath(parallelNum int, list []*filer_pb.SubscribeMetadataResponse) [][]*filer_pb.SubscribeMetadataResponse {
+	// build a tree. the value is the affected index of list.
+	rootTree := ParallelSyncNode{path: "/", fullPath: []string{}, key: ""}
+
+	for i := 0; i < len(list); i++ {
+		resp := list[i]
+		var sourceOldKey, sourceNewKey util.FullPath
+		if resp.EventNotification.OldEntry != nil {
+			sourceOldKey = util.FullPath(resp.Directory).Child(resp.EventNotification.OldEntry.Name)
+		}
+		if resp.EventNotification.NewEntry != nil {
+			sourceNewKey = util.FullPath(resp.EventNotification.NewParentPath).Child(resp.EventNotification.NewEntry.Name)
+		}
+
+		affectedPath := sourceOldKey
+		if sourceOldKey == "" {
+			affectedPath = sourceNewKey
+		}
+
+		if sourceOldKey != "" && sourceNewKey == "" {
+			fmt.Printf("DELETE: %s   %d\n", sourceOldKey, i)
+		} else if sourceOldKey == "" && sourceNewKey != "" {
+			fmt.Printf("CREATE: %s   %d\n", sourceNewKey, i)
+		} else {
+			fmt.Printf("UPDATE: %s -> %s   %d\n", sourceOldKey, sourceNewKey, i)
+		}
+
+		rootTree.addNode(i, affectedPath.Split())
+	}
+
+	return getParallelSyncWorkerArray(rootTree, parallelNum, list)
+}
+
+// Assign tasks to each worker's array
+func getParallelSyncWorkerArray(rootTree ParallelSyncNode, parallelNum int, list []*filer_pb.SubscribeMetadataResponse) [][]*filer_pb.SubscribeMetadataResponse {
+	var workerGroupResultArray [][]int
+	getParallelSyncIndexByNode(rootTree, &workerGroupResultArray)
+
+	tmp, _ := json.Marshal(workerGroupResultArray)
+	fmt.Printf("SORT:%s\n", string(tmp))
+
+	result := make([][]*filer_pb.SubscribeMetadataResponse, parallelNum)
+	if workerGroupResultArray == nil {
+		return result
+	}
+	for _, d := range workerGroupResultArray {
+		var itemGroup []*filer_pb.SubscribeMetadataResponse
+		for _, i := range d {
+			itemGroup = append(itemGroup, list[i])
+		}
+		// distribute tasks as evenly as possible
+		mIdx := getMinLenIdxFromWorkerGroup(result)
+		result[mIdx] = append(result[mIdx], itemGroup...)
+	}
+	for i := 0; i < len(result); i++ {
+		fmt.Printf(" %d ", len(result[i]))
+		if i == len(result)-1 {
+			fmt.Println()
+		}
+	}
+	return result
+}
+
+func getMinLenIdxFromWorkerGroup(workerGroup [][]*filer_pb.SubscribeMetadataResponse) int {
+	mIdx := 0
+	m := len(workerGroup[0])
+	for i := 0; i < len(workerGroup); i++ {
+		l := len(workerGroup[i])
+		if l < m {
+			mIdx = i
+			m = l
+		}
+	}
+	return mIdx
+}
+
+func getParallelSyncIndexByNode(node ParallelSyncNode, splitResult *[][]int) {
+	if len(node.value) > 0 {
+		// a litter of value
+		var aLitterOfValue []int
+		node.getAllValue(&aLitterOfValue)
+		if len(aLitterOfValue) > 0 {
+			sort.Ints(aLitterOfValue)
+			*splitResult = append(*splitResult, aLitterOfValue)
+		}
+	} else {
+		if node.hasChild() {
+			for _, child := range node.child {
+				getParallelSyncIndexByNode(*child, splitResult)
+			}
+		}
+	}
+}
+
+// get all child value of node
+func (p *ParallelSyncNode) getAllValue(values *[]int) {
+	for _, d := range p.value {
+		if d > -1 {
+			*values = append(*values, d)
+		}
+	}
+	if p.hasChild() {
+		for _, child := range p.child {
+			child.getAllValue(values)
+		}
+	}
+}
+
+func (p *ParallelSyncNode) addNode(curIdx int, curNodePathArray []string) (bool, *ParallelSyncNode) {
+	if len(curNodePathArray) > 0 {
+		curPath := curNodePathArray[0]
+		curFullPathName := "/" + curPath
+		if p.path != "/" {
+			curFullPathName = p.path + "/" + curPath
+		}
+
+		for _, child := range p.child {
+			if child.key == curPath {
+				if len(curNodePathArray) > 1 {
+					return child.addNode(curIdx, curNodePathArray[1:])
+				} else {
+					child.value = append(child.value, curIdx)
+					return true, child
+				}
+			}
+		}
+		// add new node to p.child
+		fP := strings.Split(curFullPathName, "/")[1:]
+		idx := -1
+		if len(curNodePathArray) == 1 {
+			idx = curIdx
+		}
+
+		newNode := ParallelSyncNode{
+			key:      curPath,
+			value:    []int{},
+			path:     curFullPathName,
+			fullPath: fP,
+			child:    []*ParallelSyncNode{},
+		}
+		p.child = append(p.child, &newNode)
+		// it's not over. need to continue to add children to newNode
+		if len(curNodePathArray) > 1 {
+			return newNode.addNode(curIdx, curNodePathArray[1:])
+		} else {
+			newNode.value = append(newNode.value, idx)
+			return false, &newNode
+		}
+	} else {
+		return false, nil
+	}
+}
+
+func (p *ParallelSyncNode) hasChild() bool {
+	return len(p.child) > 0
+}
+
+func (p *ParallelSyncNode) addChild(child *ParallelSyncNode) {
+	p.child = append(p.child, child)
+}

--- a/weed/command/filer_sync_parallel.go
+++ b/weed/command/filer_sync_parallel.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/pb"
@@ -138,15 +137,6 @@ func splitMetadataResponseByPath(parallelNum int, list []*filer_pb.SubscribeMeta
 		if sourceOldKey == "" {
 			affectedPath = sourceNewKey
 		}
-
-		if sourceOldKey != "" && sourceNewKey == "" {
-			fmt.Printf("DELETE: %s   %d\n", sourceOldKey, i)
-		} else if sourceOldKey == "" && sourceNewKey != "" {
-			fmt.Printf("CREATE: %s   %d\n", sourceNewKey, i)
-		} else {
-			fmt.Printf("UPDATE: %s -> %s   %d\n", sourceOldKey, sourceNewKey, i)
-		}
-
 		rootTree.addNode(i, affectedPath.Split())
 	}
 
@@ -157,9 +147,6 @@ func splitMetadataResponseByPath(parallelNum int, list []*filer_pb.SubscribeMeta
 func getParallelSyncWorkerArray(rootTree ParallelSyncNode, parallelNum int, list []*filer_pb.SubscribeMetadataResponse) [][]*filer_pb.SubscribeMetadataResponse {
 	var workerGroupResultArray [][]int
 	getParallelSyncIndexByNode(rootTree, &workerGroupResultArray)
-
-	tmp, _ := json.Marshal(workerGroupResultArray)
-	fmt.Printf("SORT:%s\n", string(tmp))
 
 	result := make([][]*filer_pb.SubscribeMetadataResponse, parallelNum)
 	if workerGroupResultArray == nil {
@@ -174,12 +161,7 @@ func getParallelSyncWorkerArray(rootTree ParallelSyncNode, parallelNum int, list
 		mIdx := getMinLenIdxFromWorkerGroup(result)
 		result[mIdx] = append(result[mIdx], itemGroup...)
 	}
-	for i := 0; i < len(result); i++ {
-		fmt.Printf(" %d ", len(result[i]))
-		if i == len(result)-1 {
-			fmt.Println()
-		}
-	}
+
 	return result
 }
 

--- a/weed/command/filer_sync_test.go
+++ b/weed/command/filer_sync_test.go
@@ -1,0 +1,506 @@
+// Package
+// @Author quzhihao
+// @Date 2022/6/23
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// test add files
+// ADD ACTION: add 100 folder and Each folder contains 100 1kb files
+//  sync cost: 190s
+// async cost: 26s [parallel number: 10, batch: 100, period:10s]
+// async cost: 21s [parallel number: 20, batch: 200, period:10s]
+// async cost: 22s [parallel number: 20, batch: 500, period:10s]
+// async cost: 23s [parallel number: 20, batch: 1000, period:10s]
+func TestParallelSyncBatchAddFiles(t *testing.T) {
+	fileFolderNumber := 10
+	fileNumber := 100
+
+	aFilerUrl := "http://localhost:8888/test1"
+	client := &http.Client{Transport: &http.Transport{
+		MaxIdleConns:        1024,
+		MaxIdleConnsPerHost: 1024,
+	}}
+	startTime := time.Now()
+	filename := "./filer_sync_test.go"
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	// test 1kb
+	buffer := make([]byte, 1024)
+
+	for {
+		_, err := file.Read(buffer)
+		if err != nil {
+			if err != io.EOF {
+				fmt.Println(err)
+			}
+			break
+		}
+	}
+
+	for i := 0; i < fileFolderNumber; i++ {
+		// create filerNumber files
+		for j := 0; j < fileNumber; j++ {
+			address := aFilerUrl + "/" + strconv.Itoa(i) + "/" + strconv.Itoa(j)
+			body := &bytes.Buffer{}
+			writer := multipart.NewWriter(body)
+			part, err := writer.CreateFormFile("file", file.Name())
+			part.Write(buffer)
+			// _, err = io.Copy(part, b)
+			err = writer.Close()
+			request, err := http.NewRequest("POST", address, body)
+			// "multipart/form-data; boundary=----WebKitFormBoundaryPQf3xOuxHYxoJhLe"
+			request.Header.Set("Content-Type", writer.FormDataContentType())
+			resp, err := client.Do(request)
+			if err != err {
+				fmt.Printf("post %s error.", address)
+			}
+			resp.Body.Close()
+		}
+	}
+	fmt.Printf("cost: %0.2fs\n", time.Since(startTime).Seconds())
+}
+
+// test delete files
+// DELETE ACTION: Recursive delete 100 folder and Each folder contains 100 1kb files
+//  sync cost: 88s
+// async cost: 24s [parallel number: 10, batch: 100, period:10s]
+// async cost: 13s [parallel number: 20, batch: 200, period:10s]
+// async cost: 7s [parallel number: 20, batch: 500, period:10s]
+// async cost: 6s [parallel number: 20, batch: 1000, period:10s]
+func TestParallelSyncBatchDeleteFiles(t *testing.T) {
+	// Can be tested in linkage with TestParallelSyncBatchAddFiles
+	fileFolderNumber := 10
+	fileNumber := 100
+
+	aFilerUrl := "http://localhost:8888/test1"
+	client := &http.Client{Transport: &http.Transport{
+		MaxIdleConns:        1024,
+		MaxIdleConnsPerHost: 1024,
+	}}
+	startTime := time.Now()
+	// delete all files
+	for i := 0; i < fileFolderNumber; i++ {
+		folderAddress := aFilerUrl + "/" + strconv.Itoa(i)
+		for j := 0; j < fileNumber; j++ {
+			address := folderAddress + "/" + strconv.Itoa(j)
+			request, err := http.NewRequest("DELETE", address, nil)
+			resp, err := client.Do(request)
+			if err != nil {
+				fmt.Printf("delete %s error.", address)
+			}
+			resp.Body.Close()
+		}
+		// delete all folders
+		requestFolder, err := http.NewRequest("DELETE", folderAddress, nil)
+		resp, err := client.Do(requestFolder)
+		if err != err {
+			fmt.Printf("delete %s error.", folderAddress)
+		}
+		resp.Body.Close()
+	}
+	fmt.Printf("cost: %0.2fs\n", time.Since(startTime).Seconds())
+}
+
+// Multi-level add and delete modifications to ensure priority
+func TestParallelSyncHybrid(t *testing.T) {
+	deleteFolder := true
+	rootPath := "/test1"
+	aFilerUrl := "http://localhost:8888" + rootPath
+
+	var renameList []string
+
+	client := &http.Client{Transport: &http.Transport{
+		MaxIdleConns:        1024,
+		MaxIdleConnsPerHost: 1024,
+	}}
+	startTime := time.Now()
+	filename := "./filer_sync_test.go"
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	// test 1kb
+	buffer := make([]byte, 1024)
+
+	for {
+		_, err := file.Read(buffer)
+		if err != nil {
+			if err != io.EOF {
+				fmt.Println(err)
+			}
+			break
+		}
+	}
+
+	data := [][]map[string]string{
+		0: {
+			{
+				"action": "addChild",
+				"value":  "1,2,3,4,5",
+			},
+			{
+				"action": "deleteChild",
+				"value":  "1,2",
+			},
+		},
+		1: {
+			{
+				"action": "addChild",
+				"value":  "6,7,8,9,10",
+			},
+			{
+				"action": "move",
+				"value":  "6,7,8,9,10:/2",
+			},
+			{
+				"action": "delete",
+				"value":  "",
+			},
+		},
+		2: {
+			{
+				"action": "addChild",
+				"value":  "1,2,3",
+			},
+			{
+				"action": "rename",
+				"value":  "2-modified",
+			},
+			{
+				"action": "addChild",
+				"value":  "4,5",
+			},
+		},
+		3: {
+			{
+				"action": "addChild",
+				"value":  "11,12",
+			},
+			{
+				"action": "rename",
+				"value":  "3-modified",
+			},
+			{
+				"action": "move",
+				"value":  "11:/0",
+			},
+		},
+	}
+
+	for i := 0; i < len(data); i++ {
+		process := data[i]
+		name := strconv.Itoa(i)
+		renameList = append(renameList, name)
+		for _, action := range process {
+			value := action["value"]
+			if action["action"] == "addChild" {
+				childNames := strings.Split(value, ",")
+				for _, childName := range childNames {
+					address := aFilerUrl + "/" + name + "/" + childName
+					body := &bytes.Buffer{}
+					writer := multipart.NewWriter(body)
+					part, err := writer.CreateFormFile("file", file.Name())
+					part.Write(buffer)
+					err = writer.Close()
+					request, err := http.NewRequest("POST", address, body)
+					request.Header.Set("Content-Type", writer.FormDataContentType())
+					resp, err := client.Do(request)
+					if err != err {
+						fmt.Printf("post %s error.", address)
+					}
+					resp.Body.Close()
+				}
+			} else if action["action"] == "deleteChild" {
+				childNames := strings.Split(value, ",")
+				for _, childName := range childNames {
+					address := aFilerUrl + "/" + name + "/" + childName
+					request, err := http.NewRequest("DELETE", address, nil)
+					resp, err := client.Do(request)
+					if err != err {
+						fmt.Printf("post %s error.", address)
+					}
+					resp.Body.Close()
+				}
+			} else if action["action"] == "delete" {
+				address := aFilerUrl + "/" + name + "?recursive=true&ignoreRecursiveError=true"
+				request, err := http.NewRequest("DELETE", address, nil)
+				resp, err := client.Do(request)
+				if err != err {
+					fmt.Printf("post %s error.", address)
+				}
+				resp.Body.Close()
+			} else if action["action"] == "rename" {
+				moveAddress := aFilerUrl + "/" + value + "?mv.from=" + rootPath + "/" + name
+				request, err := http.NewRequest("POST", moveAddress, nil)
+				resp, err := client.Do(request)
+				if err != err {
+					fmt.Printf("post %s error.", moveAddress)
+				}
+				resp.Body.Close()
+				name = value
+				renameList = append(renameList, name)
+			} else if action["action"] == "move" {
+				operatorArray := strings.Split(value, ":")
+				childNames := strings.Split(operatorArray[0], ",")
+				targetFolder := operatorArray[1]
+				for _, childName := range childNames {
+					moveAddress := aFilerUrl + targetFolder + "/" + childName + "?mv.from=" + rootPath + "/" + name + "/" + childName
+					request, err := http.NewRequest("POST", moveAddress, nil)
+					resp, err := client.Do(request)
+					if err != err {
+						fmt.Printf("post %s error.", moveAddress)
+					}
+					resp.Body.Close()
+				}
+			}
+		}
+	}
+
+	// you can delete all affected files
+	if deleteFolder {
+		fmt.Println("DELETE Folder")
+		for i := 0; i < len(renameList); i++ {
+			fmt.Printf("%s\n", renameList[i])
+			address := aFilerUrl + "/" + renameList[i] + "?recursive=true&ignoreRecursiveError=true"
+			request, err := http.NewRequest("DELETE", address, nil)
+			resp, err := client.Do(request)
+			if err != err {
+				fmt.Printf("post %s error.", address)
+			}
+			resp.Body.Close()
+		}
+	}
+
+	fmt.Printf("cost: %0.2fs\n", time.Since(startTime).Seconds())
+}
+
+// folder 0~9 to 10
+func TestParallelSyncMove(t *testing.T) {
+	fileFolderNumber := 10
+	fileNumber := 1
+	deleteFolder := true
+
+	rootPath := "/test1"
+	aFilerUrl := "http://localhost:8888" + rootPath
+	client := &http.Client{Transport: &http.Transport{
+		MaxIdleConns:        1024,
+		MaxIdleConnsPerHost: 1024,
+	}}
+	startTime := time.Now()
+	filename := "./filer_sync_test.go"
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	// test 1kb
+	buffer := make([]byte, 1024)
+
+	for {
+		_, err := file.Read(buffer)
+		if err != nil {
+			if err != io.EOF {
+				fmt.Println(err)
+			}
+			break
+		}
+	}
+
+	for i := 0; i < fileFolderNumber+1; i++ {
+		if i == fileFolderNumber {
+			address := aFilerUrl + "/" + strconv.Itoa(i) + "/"
+			request, err := http.NewRequest("POST", address, nil)
+			resp, err := client.Do(request)
+			if err != err {
+				fmt.Printf("post %s error.", address)
+			}
+			resp.Body.Close()
+			break
+		}
+		// create filerNumber files
+		for j := 0; j < fileNumber; j++ {
+			address := aFilerUrl + "/" + strconv.Itoa(i) + "/" + strconv.Itoa(j)
+			body := &bytes.Buffer{}
+			writer := multipart.NewWriter(body)
+			part, err := writer.CreateFormFile("file", file.Name())
+			part.Write(buffer)
+			err = writer.Close()
+			request, err := http.NewRequest("POST", address, body)
+			request.Header.Set("Content-Type", writer.FormDataContentType())
+			resp, err := client.Do(request)
+			if err != err {
+				fmt.Printf("post %s error.", address)
+			}
+			resp.Body.Close()
+		}
+	}
+	// move
+	for i := 0; i < fileFolderNumber; i++ {
+		// move filerNumber files to "10"
+		for j := 0; j < fileNumber; j++ {
+			address := aFilerUrl + "/" + strconv.Itoa(i) + "/" + strconv.Itoa(j)
+			moveAddress := aFilerUrl + "/" + strconv.Itoa(fileFolderNumber) + "/" + strconv.Itoa(i) + "?mv.from=" + rootPath + "/" + strconv.Itoa(i) + "/0"
+			fmt.Printf("%s\n", moveAddress)
+			request, err := http.NewRequest("POST", moveAddress, nil)
+			resp, err := client.Do(request)
+			if err != err {
+				fmt.Printf("post %s error.", address)
+			}
+			resp.Body.Close()
+		}
+	}
+	// delete all files
+	if deleteFolder {
+		for i := 0; i < fileFolderNumber; i++ {
+			address := aFilerUrl + "/" + strconv.Itoa(i) + "/"
+			request, err := http.NewRequest("DELETE",
+				address, nil)
+			resp, err := client.Do(request)
+			if err != err {
+				fmt.Printf("post %s error.", address)
+			}
+			resp.Body.Close()
+		}
+		fmt.Printf("cost: %0.2fs\n", time.Since(startTime).Seconds())
+	}
+
+}
+
+func TestParallelSyncSplitNodes(t *testing.T) {
+	// a total of 13 numbers
+	// The asterisk indicates that this node has been operated.
+	rootTree := ParallelSyncNode{path: "/", fullPath: []string{}, key: ""}
+	//              /
+	//    1         5        10
+	//   2*       6 7* 8      11*
+	//  3* 4     9*            12
+	basePoint := [][]string{
+		0: {"1", "2", "3"},
+		1: {"1", "2", "4"},
+		2: {"5", "7"},
+		3: {"5", "8"},
+		4: {"5", "6", "9"},
+		5: {"10", "11", "12"},
+	}
+	// hit number
+	hitPoint := [][]string{
+		0: {"1", "2"},
+		1: {"1", "2", "3"},
+		2: {"5", "7"},
+		3: {"5", "6", "9"},
+		4: {"10", "11"},
+	}
+	for _, v := range basePoint {
+		rootTree.addNode(-1, v)
+	}
+
+	for _, v := range hitPoint {
+		a, _ := strconv.Atoi(v[len(v)-1])
+		rootTree.addNode(a, v)
+	}
+
+	var list []*filer_pb.SubscribeMetadataResponse
+	for i := 0; i < 13; i++ {
+		item := filer_pb.SubscribeMetadataResponse{
+			Directory: strconv.Itoa(i),
+		}
+		list = append(list, &item)
+	}
+
+	var workerGroupResultArray [][]int
+	getParallelSyncIndexByNode(rootTree, &workerGroupResultArray)
+
+	assert.EqualValues(t, workerGroupResultArray[0], []int{2, 3})
+	assert.EqualValues(t, workerGroupResultArray[1], []int{7})
+	assert.EqualValues(t, workerGroupResultArray[2], []int{9})
+	assert.EqualValues(t, workerGroupResultArray[3], []int{11})
+}
+
+func TestGetMinLenIdxFromWorkerGroup(t *testing.T) {
+	var workerGroup = make([][]*filer_pb.SubscribeMetadataResponse, 5)
+
+	data1 := []int{
+		5, 4, 3, 2, 1,
+	}
+
+	for i := 0; i < data1[0]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[0] = append(workerGroup[0], tmp)
+	}
+
+	for i := 0; i < data1[1]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[1] = append(workerGroup[1], tmp)
+	}
+
+	for i := 0; i < data1[2]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[2] = append(workerGroup[2], tmp)
+	}
+
+	for i := 0; i < data1[3]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[3] = append(workerGroup[3], tmp)
+	}
+
+	for i := 0; i < data1[4]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[4] = append(workerGroup[4], tmp)
+	}
+
+	result := getMinLenIdxFromWorkerGroup(workerGroup)
+	assert.Equal(t, 4, result)
+
+	data2 := []int{
+		3, 4, 1, 2, 5,
+	}
+
+	for i := 0; i < data2[0]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[0] = append(workerGroup[0], tmp)
+	}
+
+	for i := 0; i < data2[1]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[1] = append(workerGroup[1], tmp)
+	}
+
+	for i := 0; i < data2[2]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[2] = append(workerGroup[2], tmp)
+	}
+
+	for i := 0; i < data2[3]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[3] = append(workerGroup[3], tmp)
+	}
+
+	for i := 0; i < data2[4]; i++ {
+		var tmp *filer_pb.SubscribeMetadataResponse
+		workerGroup[4] = append(workerGroup[4], tmp)
+	}
+
+	result = getMinLenIdxFromWorkerGroup(workerGroup)
+	assert.Equal(t, 2, result)
+}

--- a/weed/command/filer_sync_test.go
+++ b/weed/command/filer_sync_test.go
@@ -21,12 +21,11 @@ import (
 // test add files
 // ADD ACTION: add 100 folder and Each folder contains 100 1kb files
 //  sync cost: 190s
-// async cost: 26s [parallel number: 10, batch: 100, period:10s]
-// async cost: 21s [parallel number: 20, batch: 200, period:10s]
-// async cost: 22s [parallel number: 20, batch: 500, period:10s]
-// async cost: 23s [parallel number: 20, batch: 1000, period:10s]
+// async cost: 165s [parallel number: 10, batch: 500, period:15s]
+// async cost: 140s [parallel number: 10, batch: 1000, period:10s]
+// async cost: 140s [parallel number: 20, batch: 1000, period:20s]
 func TestParallelSyncBatchAddFiles(t *testing.T) {
-	fileFolderNumber := 10
+	fileFolderNumber := 100
 	fileNumber := 100
 
 	aFilerUrl := "http://localhost:8888/test1"
@@ -81,13 +80,12 @@ func TestParallelSyncBatchAddFiles(t *testing.T) {
 // test delete files
 // DELETE ACTION: Recursive delete 100 folder and Each folder contains 100 1kb files
 //  sync cost: 88s
-// async cost: 24s [parallel number: 10, batch: 100, period:10s]
-// async cost: 13s [parallel number: 20, batch: 200, period:10s]
-// async cost: 7s [parallel number: 20, batch: 500, period:10s]
-// async cost: 6s [parallel number: 20, batch: 1000, period:10s]
+// async cost: 75s [parallel number: 10, batch: 500, period:15s]
+// async cost: 65s [parallel number: 10, batch: 1000, period:20s]
+// async cost: 61s [parallel number: 20, batch: 1000, period:20s]
 func TestParallelSyncBatchDeleteFiles(t *testing.T) {
 	// Can be tested in linkage with TestParallelSyncBatchAddFiles
-	fileFolderNumber := 10
+	fileFolderNumber := 100
 	fileNumber := 100
 
 	aFilerUrl := "http://localhost:8888/test1"


### PR DESCRIPTION
# What problem are we solving?
One filerSink synchronization is too slow. I intend to synchronize with multiple filerSink.  
This increases the processing speed.

# How are we solving the problem?
(1) Split data and execution order.
Split by pathname.
I'm going to use a tree structure, and extract the affected event path. 
The affected set is placed separately in a worker thread. This ensures the correct send order.
The top level of operation will put the children into a collection, and the speed increase is relatively small.

(2) Multiple sending threads
Create multiple FilerSink during initialization to assign to worker thread.
This is the report that I created multiple 1kb files in my unit test.
```
Add 100 folder and Each folder contains 100 1kb files. As it is a stand-alone machine, it has a certain impact.
sync cost: 190s
async cost: 165s [parallel number: 10, batch: 500, period:15s]
async cost: 140s [parallel number: 10, batch: 1000, period:10s]
async cost: 140s [parallel number: 20, batch: 1000, period:20s]
```

(3) Related parameters
* a.parallelNum, b.parallelNum: 
    Number of synchronization workers. The default value is 1, using the original logic.
* a.parallelBatchSize, b.parallelBatchSize: 
    Number of events handled at a time. This parameter takes effect only if x is greater than 1.
* parallelMaxInterval:  
    Maximum processing interval.

(4) Fix bug: nanosecond timestamp display
the value of lastLogTsNs should be used  ```time.Now().UnixNano()``` instead of ```time.Now().Nanosecond```

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
