### PR TITLE
fix 3238: handle errors for GenerateDirUuid method

### DIFF
--- a/weed/storage/disk_location.go
+++ b/weed/storage/disk_location.go
@@ -44,13 +44,11 @@ func GenerateDirUuid(dir string) (dirUuidString string, err error) {
 		dirUuidString = dirUuid.String()
 		writeErr := util.WriteFile(fileName, []byte(dirUuidString), 0644)
 		if writeErr != nil {
-			glog.Warningf("failed to write uuid to %s : %v", fileName, writeErr)
 			return "", fmt.Errorf("failed to write uuid to %s : %v", fileName, writeErr)
 		}
 	} else {
 		uuidData, readErr := os.ReadFile(fileName)
 		if readErr != nil {
-			glog.Warningf("failed to read uuid from %s : %v", fileName, readErr)
 			return "", fmt.Errorf("failed to read uuid from %s : %v", fileName, readErr)
 		}
 		dirUuidString = string(uuidData)
@@ -65,7 +63,10 @@ func NewDiskLocation(dir string, maxVolumeCount int, minFreeSpace util.MinFreeSp
 	} else {
 		idxDir = util.ResolvePath(idxDir)
 	}
-	dirUuid, _ := GenerateDirUuid(dir)
+	dirUuid, err := GenerateDirUuid(dir)
+	if err != nil {
+		glog.Fatalf("cannot generate uuid of dir %s: %v", dir, err)
+	}
 	location := &DiskLocation{
 		Directory:              dir,
 		DirectoryUuid:          dirUuid,


### PR DESCRIPTION
# What problem are we solving?
#3238  Volume server doesn't handle errors for GenerateDirUuid method. 

# How are we solving the problem?
Log errors for GenerateDirUuid method and exit.

```
I0627 21:57:27 82171 file_util.go:23] Folder /var/lib/data-backup/restricted_folder Permission: -rw-------
I0627 21:57:27 82171 disk_location.go:39] Getting uuid of volume directory:/var/lib/data-backup/restricted_folder
F0627 21:57:27 82171 disk_location.go:68] cannot generate uuid of dir /var/lib/data-backup/restricted_folder: failed to read uuid from /var/lib/data-backup/restricted_folder/vol_dir.uuid : open /var/lib/data-backup/restricted_folder/vol_dir.uuid: permission denied
goroutine 1 [running]:
github.com/chrislusf/seaweedfs/weed/glog.stacks(0x0)
        D:/codes/github/seaweedfs/weed/glog/glog.go:767 +0x8a
github.com/chrislusf/seaweedfs/weed/glog.(*loggingT).output(0x39b0fe0, 0x3, 0xc00091a150, {0x2dd7349?, 0xc0009bf448?}, 0x2?, 0x0)
        D:/codes/github/seaweedfs/weed/glog/glog.go:718 +0x3ab
github.com/chrislusf/seaweedfs/weed/glog.(*loggingT).printf(0x7ffd0bc46543?, 0x26?, {0x22ffdd1, 0x22}, {0xc0009bf448, 0x2, 0x2})
        D:/codes/github/seaweedfs/weed/glog/glog.go:656 +0x110
github.com/chrislusf/seaweedfs/weed/glog.Fatalf(...)
        D:/codes/github/seaweedfs/weed/glog/glog.go:1149
github.com/chrislusf/seaweedfs/weed/storage.NewDiskLocation({0x7ffd0bc46543?, 0xc0009bf508?}, 0x8, {0x0, 0x0, 0x3f800000, {0x22b4201, 0x1}}, {0x0, 0x0}, ...)
        D:/codes/github/seaweedfs/weed/storage/disk_location.go:68 +0x16d
github.com/chrislusf/seaweedfs/weed/storage.NewStore({0x2882920?, 0xc00000e280}, {0xc00056d480, 0xd}, 0x1f90, 0x46a0, {0xc00014b818, 0x12}, {0xc000862210, 0x1, ...}, ...)
        D:/codes/github/seaweedfs/weed/storage/store.go:73 +0x38d
github.com/chrislusf/seaweedfs/weed/server.NewVolumeServer(_, _, {_, _}, _, _, {_, _}, {0xc000862210, 0x1, ...}, ...)
        D:/codes/github/seaweedfs/weed/server/volume_server.go:101 +0x5a5
github.com/chrislusf/seaweedfs/weed/command.VolumeServerOptions.startVolumeServer({0xc00056d418, 0xc00056d430, 0xc00056d438, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, 0xc0002d1790, ...}, ...)
        D:/codes/github/seaweedfs/weed/command/volume.go:237 +0xeb8
github.com/chrislusf/seaweedfs/weed/command.runVolume(0x39944b8?, {0xc00004c0e0?, 0x1?, 0x1?})
        D:/codes/github/seaweedfs/weed/command/volume.go:133 +0x196
main.main()
        D:/codes/github/seaweedfs/weed/weed.go:81 +0x383
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
