### PR TITLE
avoid set currentMaster svc.local k8s discovery service domains

### DIFF
--- a/weed/security/tls.go
+++ b/weed/security/tls.go
@@ -35,7 +35,7 @@ func LoadServerTLS(config *util.ViperProxy, component string) (grpc.ServerOption
 
 	serverIdentityProvider, err := pemfile.NewProvider(serverOptions)
 	if err != nil {
-		glog.Warningf("pemfile.NewProvider(%v) failed: %v", serverOptions, err)
+		glog.Warningf("pemfile.NewProvider(%v) %v failed: %v", serverOptions, component, err)
 		return nil, nil
 	}
 

--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -263,8 +263,12 @@ func (ms *MasterServer) KeepConnected(stream master_pb.Seaweed_KeepConnectedServ
 		}
 		ms.deleteClient(clientName)
 	}()
-
-	for _, message := range ms.Topo.ToVolumeLocations() {
+	for i, message := range ms.Topo.ToVolumeLocations() {
+		if i == 0 {
+			if leader, err := ms.Topo.Leader(); err == nil {
+				message.Leader = string(leader)
+			}
+		}
 		if sendErr := stream.Send(&master_pb.KeepConnectedResponse{VolumeLocation: message}); sendErr != nil {
 			return sendErr
 		}

--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -188,8 +188,8 @@ func (mc *MasterClient) tryConnectToMaster(master pb.ServerAddress) (nextHintedL
 
 			if resp.VolumeLocation != nil {
 				// maybe the leader is changed
-				if resp.VolumeLocation.Leader != "" {
-					glog.V(0).Infof("redirected to leader %v", resp.VolumeLocation.Leader)
+				if resp.VolumeLocation.Leader != "" && string(mc.currentMaster) != resp.VolumeLocation.Leader {
+					glog.V(0).Infof("currentMaster %v redirected to leader %v", mc.currentMaster, resp.VolumeLocation.Leader)
 					nextHintedLeader = pb.ServerAddress(resp.VolumeLocation.Leader)
 					stats.MasterClientConnectCounter.WithLabelValues(stats.RedirectedToleader).Inc()
 					return nil

--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -168,8 +168,8 @@ func (mc *MasterClient) tryConnectToMaster(master pb.ServerAddress) (nextHintedL
 		}
 
 		// check if it is the leader to determine whether to reset the vidMap
-		if resp.VolumeLocation != nil && resp.VolumeLocation.Leader != "" {
-			glog.V(0).Infof("redirected to leader %v", resp.VolumeLocation.Leader)
+		if resp.VolumeLocation != nil && resp.VolumeLocation.Leader != "" && string(master) != resp.VolumeLocation.Leader {
+			glog.V(0).Infof("master %v redirected to leader %v", master, resp.VolumeLocation.Leader)
 			nextHintedLeader = pb.ServerAddress(resp.VolumeLocation.Leader)
 			stats.MasterClientConnectCounter.WithLabelValues(stats.RedirectedToleader).Inc()
 			return nil


### PR DESCRIPTION
https://github.com/chrislusf/seaweedfs/issues/2589

# What problem are we solving?

discovery dns name set as currentMaster

# How are we solving the problem?

always set leader for keepconnected for set it as currentMaster

https://github.com/chrislusf/seaweedfs/issues/2589

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
