### PR TITLE
Fixes WebDAV 0-bytes files

### DIFF
--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -48,6 +48,13 @@ type WebDavServer struct {
 	Handler        *webdav.Handler
 }
 
+func max(x, y int64) int64 {
+	if x <= y {
+		return y
+	}
+	return x
+}
+
 func NewWebDavServer(option *WebDavOption) (ws *WebDavServer, err error) {
 
 	fs, _ := NewWebDavFileSystem(option)
@@ -496,6 +503,7 @@ func (f *WebDavFile) Write(buf []byte) (int, error) {
 	written, err := f.bufWriter.Write(buf)
 
 	if err == nil {
+		f.entry.Attributes.FileSize = uint64(max(f.off+int64(written), int64(f.entry.Attributes.FileSize)))
 		glog.V(3).Infof("WebDavFileSystem.Write %v: written [%d,%d)", f.name, f.off, f.off+int64(len(buf)))
 		f.off += int64(written)
 	}


### PR DESCRIPTION
Fixes the issue where files created via WebDAV show as 0-bytes size when read via fuse.

# What problem are we solving?

https://github.com/chrislusf/seaweedfs/issues/3217


# How are we solving the problem?

Set the fileSize Attribute after writing the file, like is done for fuse writes.


# Checks
None  -  reproduced as described in the issue, issued sync, found file-size and the ms5sum
to be as expected.