### PR TITLE
close SkipCheckParentDirectory flag

### DIFF
--- a/weed/filer/read_write.go
+++ b/weed/filer/read_write.go
@@ -2,9 +2,10 @@ package filer
 
 import (
 	"bytes"
+	"time"
+
 	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
 	"github.com/chrislusf/seaweedfs/weed/wdclient"
-	"time"
 )
 
 func ReadEntry(masterClient *wdclient.MasterClient, filerClient filer_pb.SeaweedFilerClient, dir, name string, byteBuffer *bytes.Buffer) error {
@@ -60,7 +61,7 @@ func SaveInsideFiler(client filer_pb.SeaweedFilerClient, dir, name string, conte
 				},
 				Content: content,
 			},
-			SkipCheckParentDirectory: true,
+			SkipCheckParentDirectory: false,
 		})
 	} else if err == nil {
 		entry := resp.Entry


### PR DESCRIPTION
# What problem are we solving?

After running `s3.configure` in weed shell, we can't see the `/etc/iam/identity.json` entry unless we create directory `/etc/iam` manually.

# How are we solving the problem?
We solving this problem by setting `SkipCheckParentDirectory` flag to `false`, so the directory where the entry resides will be created automatically.

# Checks
- [√] I have added unit tests if possible.
- [√] I will add related wiki document changes and link to this PR after merging.
