### PR TITLE
Check duplicate access key

### DIFF
--- a/weed/filer/s3iam_conf.go
+++ b/weed/filer/s3iam_conf.go
@@ -2,9 +2,13 @@ package filer
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/chrislusf/seaweedfs/weed/pb/iam_pb"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"io"
 )
 
 func ParseS3ConfigurationFromBytes[T proto.Message](content []byte, config T) error {
@@ -22,4 +26,19 @@ func ProtoToText(writer io.Writer, config proto.Message) error {
 	}
 
 	return m.Marshal(writer, config)
+}
+
+// CheckDuplicateAccessKey returns an error message when s3cfg has duplicate access keys
+func CheckDuplicateAccessKey(s3cfg *iam_pb.S3ApiConfiguration) error {
+	accessKeySet := make(map[string]string)
+	for _, ident := range s3cfg.Identities {
+		for _, cred := range ident.Credentials {
+			if userName, found := accessKeySet[cred.AccessKey]; !found {
+				accessKeySet[cred.AccessKey] = ident.Name
+			} else {
+				return errors.New(fmt.Sprintf("duplicate accessKey[%s], already configured in user[%s]", cred.AccessKey, userName))
+			}
+		}
+	}
+	return nil
 }

--- a/weed/filer/s3iam_conf.go
+++ b/weed/filer/s3iam_conf.go
@@ -2,7 +2,6 @@ package filer
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 
@@ -36,7 +35,7 @@ func CheckDuplicateAccessKey(s3cfg *iam_pb.S3ApiConfiguration) error {
 			if userName, found := accessKeySet[cred.AccessKey]; !found {
 				accessKeySet[cred.AccessKey] = ident.Name
 			} else {
-				return errors.New(fmt.Sprintf("duplicate accessKey[%s], already configured in user[%s]", cred.AccessKey, userName))
+				return fmt.Errorf("duplicate accessKey[%s], already configured in user[%s]", cred.AccessKey, userName)
 			}
 		}
 	}

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -109,6 +109,11 @@ func (iam *IdentityAccessManagement) LoadS3ApiConfigurationFromBytes(content []b
 		glog.Warningf("unmarshal error: %v", err)
 		return fmt.Errorf("unmarshal error: %v", err)
 	}
+
+	if err := filer.CheckDuplicateAccessKey(s3ApiConfiguration); err != nil {
+		return err
+	}
+
 	if err := iam.loadS3ApiConfiguration(s3ApiConfiguration); err != nil {
 		return err
 	}

--- a/weed/shell/command_s3_configure.go
+++ b/weed/shell/command_s3_configure.go
@@ -2,13 +2,13 @@ package shell
 
 import (
 	"bytes"
-	"errors"
 	"flag"
 	"fmt"
-	"github.com/chrislusf/seaweedfs/weed/filer"
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/chrislusf/seaweedfs/weed/filer"
 
 	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
 	"github.com/chrislusf/seaweedfs/weed/pb/iam_pb"
@@ -165,15 +165,8 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 		s3cfg.Identities = append(s3cfg.Identities, &identity)
 	}
 
-	accessKeySet := make(map[string]string)
-	for _, ident := range s3cfg.Identities {
-		for _, cred := range ident.Credentials {
-			if userName, found := accessKeySet[cred.AccessKey]; !found {
-				accessKeySet[cred.AccessKey] = ident.Name
-			} else {
-				return errors.New(fmt.Sprintf("duplicate accessKey[%s], already configured in user[%s]", cred.AccessKey, userName))
-			}
-		}
+	if err = filer.CheckDuplicateAccessKey(s3cfg); err != nil {
+		return err
 	}
 
 	buf.Reset()


### PR DESCRIPTION
# What problem are we solving?

Issue #3304 

# How are we solving the problem?

Check duplicate access key in both [dynamic configuration](https://github.com/chrislusf/seaweedfs/wiki/Amazon-S3-API#dynamic-configuration) and [static configuration](https://github.com/chrislusf/seaweedfs/wiki/Amazon-S3-API#static-configuration).

# Checks
- [√] I have added unit tests if possible.
- [√] I will add related wiki document changes and link to this PR after merging.
