### PR TITLE
File upload should succeed should return `ETag` instead of `Etag`

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -445,9 +445,9 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, uploadUrl string, dataReader
 func setEtag(w http.ResponseWriter, etag string) {
 	if etag != "" {
 		if strings.HasPrefix(etag, "\"") {
-			w.Header().Set("ETag", etag)
+			w.Header()["ETag"] = []string{etag}
 		} else {
-			w.Header().Set("ETag", "\""+etag+"\"")
+			w.Header()["ETag"] = []string{"\"" + etag + "\""}
 		}
 	}
 }


### PR DESCRIPTION
# What problem are we solving?

When using a lower version of the s3 client (java), an exception will be thrown if the `ETag` header cannot be read

[File upload should succeed should return `ETag` instead of `Etag`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_ResponseSyntax)

at `/go-1.18.1/src/net/textproto/header.go:39`, header is canonicalized by `textproto.CanonicalMIMEHeaderKey`

# How are we solving the problem?

replace `w.Header().Set("ETag", etag)` with `w.Header()["ETag"] = []string{etag}`
replace `w.Header().Set("ETag", "\""+etag+"\"")` with `w.Header()["ETag"] = []string{"\"" + etag + "\""}`

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
