### PR TITLE
split s3 static configuration and dynamic configuration

### DIFF
--- a/weed/filer/filer_conf.go
+++ b/weed/filer/filer_conf.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/chrislusf/seaweedfs/weed/pb"
 	"github.com/chrislusf/seaweedfs/weed/wdclient"
 	"google.golang.org/grpc"
-	"io"
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
@@ -24,6 +25,7 @@ const (
 	IamConfigDirecotry    = "/etc/iam"
 	IamIdentityFile       = "identity.json"
 	IamPoliciesFile       = "policies.json"
+	IamStaticConfigFile   = "static.conf"
 )
 
 type FilerConf struct {

--- a/weed/shell/command_s3_configure.go
+++ b/weed/shell/command_s3_configure.go
@@ -48,6 +48,15 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 	}
 
 	var buf bytes.Buffer
+
+	// check whether s3 server is using a static configuration
+	if err = commandEnv.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
+		return filer.ReadEntry(commandEnv.MasterClient, client, filer.IamConfigDirecotry, filer.IamStaticConfigFile, &buf)
+	}); err != filer_pb.ErrNotFound {
+		return fmt.Errorf("s3 server is using a static configuration, so dynamic configuration is not allowed")
+	}
+
+	// read s3 server dynamic configuration
 	if err = commandEnv.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
 		return filer.ReadEntry(commandEnv.MasterClient, client, filer.IamConfigDirecotry, filer.IamIdentityFile, &buf)
 	}); err != nil && err != filer_pb.ErrNotFound {


### PR DESCRIPTION
# What problem are we solving?

If the s3 server is using a static configuration, then give an error message when the weed administrator tries to execute `s3.configure` in the weed shell.

# How are we solving the problem?
In the static configure situation, where the s3 server is started with the command `weed s3 -config=config.json`, the server writes the content of `config.json` to `/etc/iam/static.conf`. The `s3.configure` command will check if the `/etc/iam/static.conf` is existed. If the file does exist, which shows that it's a static configure situation, the proper error message is printed. Otherwise, the `s3.configure` will be executed correctly.

In the dynamic configure situation, the s3 server tries to remove `/etc/iam/static.conf` when it starts so that the `s3.configure` could do its job.

# Checks
- [√] I have added unit tests if possible.
- [√] I will add related wiki document changes and link to this PR after merging.
