### PR TITLE
avoid duplicated actions in PutUserPolicy

### DIFF
--- a/weed/iamapi/iamapi_management_handlers.go
+++ b/weed/iamapi/iamapi_management_handlers.go
@@ -219,8 +219,16 @@ func (iama *IamApiServer) PutUserPolicy(s3cfg *iam_pb.S3ApiConfiguration, values
 		if userName != ident.Name {
 			continue
 		}
+
+		existedActions := make(map[string]bool, len(ident.Actions))
+		for _, action := range ident.Actions {
+			existedActions[action] = true
+		}
+
 		for _, action := range actions {
-			ident.Actions = append(ident.Actions, action)
+			if !existedActions[action] {
+				ident.Actions = append(ident.Actions, action)
+			}
 		}
 		return resp, nil
 	}
@@ -349,7 +357,8 @@ func (iama *IamApiServer) CreateAccessKey(s3cfg *iam_pb.S3ApiConfiguration, valu
 	}
 	if !changed {
 		s3cfg.Identities = append(s3cfg.Identities,
-			&iam_pb.Identity{Name: userName,
+			&iam_pb.Identity{
+				Name: userName,
 				Credentials: []*iam_pb.Credential{
 					{
 						AccessKey: accessKeyId,


### PR DESCRIPTION
# What problem are we solving?

PutUserPolicy append `Actions` that already existed in user identity. Causing the identity ended with duplicated actions

# How are we solving the problem?

Add logic to filter our existed actions

# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
