### PR TITLE
Solve the problem that `LookupFileId` lookup urls is empty due to lea…

### DIFF
--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -23,18 +23,20 @@ type MasterClient struct {
 	grpcDialOption grpc.DialOption
 
 	vidMap
+	vidMapCacheSize int
 
 	OnPeerUpdate func(update *master_pb.ClusterNodeUpdate, startFrom time.Time)
 }
 
 func NewMasterClient(grpcDialOption grpc.DialOption, filerGroup string, clientType string, clientHost pb.ServerAddress, clientDataCenter string, masters map[string]pb.ServerAddress) *MasterClient {
 	return &MasterClient{
-		FilerGroup:     filerGroup,
-		clientType:     clientType,
-		clientHost:     clientHost,
-		masters:        masters,
-		grpcDialOption: grpcDialOption,
-		vidMap:         newVidMap(clientDataCenter),
+		FilerGroup:      filerGroup,
+		clientType:      clientType,
+		clientHost:      clientHost,
+		masters:         masters,
+		grpcDialOption:  grpcDialOption,
+		vidMap:          newVidMap(clientDataCenter),
+		vidMapCacheSize: 5,
 	}
 }
 
@@ -175,10 +177,12 @@ func (mc *MasterClient) tryConnectToMaster(master pb.ServerAddress) (nextHintedL
 				stats.MasterClientConnectCounter.WithLabelValues(stats.RedirectedToleader).Inc()
 				return nil
 			}
-			mc.vidMap = newVidMap("")
+			//mc.vidMap = newVidMap("")
+			mc.resetVidMap()
 			mc.updateVidMap(resp)
 		} else {
-			mc.vidMap = newVidMap("")
+			mc.resetVidMap()
+			//mc.vidMap = newVidMap("")
 		}
 		mc.currentMaster = master
 
@@ -262,4 +266,18 @@ func (mc *MasterClient) WithClient(streamingMode bool, fn func(client master_pb.
 			return fn(client)
 		})
 	})
+}
+
+func (mc *MasterClient) resetVidMap() {
+	tail := &vidMap{vid2Locations: mc.vid2Locations, ecVid2Locations: mc.ecVid2Locations, cache: mc.cache}
+	mc.vidMap = newVidMap("")
+	mc.vidMap.cache = tail
+
+	for i := 0; i < mc.vidMapCacheSize && tail.cache != nil; i++ {
+		if i == mc.vidMapCacheSize-1 {
+			tail.cache = nil
+		} else {
+			tail = tail.cache
+		}
+	}
 }

--- a/weed/wdclient/vid_map_test.go
+++ b/weed/wdclient/vid_map_test.go
@@ -2,6 +2,8 @@ package wdclient
 
 import (
 	"fmt"
+	"google.golang.org/grpc"
+	"strconv"
 	"testing"
 )
 
@@ -55,6 +57,71 @@ func TestLocationIndex(t *testing.T) {
 		}
 		if got != i%length {
 			t.Errorf("length: %d, i: %d, got: %d\n", length, i, got)
+		}
+	}
+}
+
+func TestLookupFileId(t *testing.T) {
+	mc := NewMasterClient(grpc.EmptyDialOption{}, "", "", "", "", nil)
+	length := 5
+
+	//Construct a cache linked list of length 5
+	for i := 0; i < length; i++ {
+		mc.addLocation(uint32(i), Location{Url: strconv.FormatInt(int64(i), 10)})
+		mc.resetVidMap()
+	}
+	for i := 0; i < length; i++ {
+		locations, found := mc.GetLocations(uint32(i))
+		if !found || len(locations) != 1 || locations[0].Url != strconv.FormatInt(int64(i), 10) {
+			t.Fatalf("urls of vid=%d is not valid.", i)
+		}
+	}
+
+	//When continue to add nodes to the linked list, the previous node will be deleted, and the cache of the response will be gone.
+	for i := length; i < length+5; i++ {
+		mc.addLocation(uint32(i), Location{Url: strconv.FormatInt(int64(i), 10)})
+		mc.resetVidMap()
+	}
+	for i := 0; i < length; i++ {
+		locations, found := mc.GetLocations(uint32(i))
+		if found {
+			t.Fatalf("urls of vid[%d] should not exists, but found: %v", i, locations)
+		}
+	}
+
+	//The delete operation will be applied to all cache nodes
+	_, found := mc.GetLocations(uint32(length))
+	if !found {
+		t.Fatalf("urls of vid[%d] not found", length)
+	}
+
+	//If the locations of the current node exist, return directly
+	newUrl := "abc"
+	mc.addLocation(uint32(length), Location{Url: newUrl})
+	locations, found := mc.GetLocations(uint32(length))
+	if !found || locations[0].Url != newUrl {
+		t.Fatalf("urls of vid[%d] not found", length)
+	}
+
+	//After delete `abc`, cache nodes are searched
+	deleteLoc := Location{Url: newUrl}
+	mc.deleteLocation(uint32(length), deleteLoc)
+	locations, found = mc.GetLocations(uint32(length))
+	if found && locations[0].Url != strconv.FormatInt(int64(length), 10) {
+		t.Fatalf("urls of vid[%d] not expected", length)
+	}
+
+	//lock: concurrent test
+	go func() {
+		for i := 0; i < 100; i++ {
+			mc.addLocation(uint32(i), Location{})
+		}
+	}()
+	for i := 0; i < 10; i++ {
+		for i := 0; i < 100; i++ {
+			for i := 0; i < 20; i++ {
+				_, _ = mc.GetLocations(uint32(i))
+			}
 		}
 	}
 }


### PR DESCRIPTION
# What problem are we solving?

fix #3327 
Solve the problem that `LookupFileId` lookup urls is empty due to leader switching

# How are we solving the problem?

The vidMap structure is modified to a linked list structure (the length is limited to 5). When the vidMap is reset, the current vidMap is added to the new vidMap as a cache node. When the query locations is empty, the cache node is searched to avoid problems when the master switches leaders.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
