### PR TITLE
feat: k8s PVC Storage for Filer and Master

### DIFF
--- a/k8s/helm_charts2/templates/_helpers.tpl
+++ b/k8s/helm_charts2/templates/_helpers.tpl
@@ -113,7 +113,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 
-{{/* check if any PVC exists */}}
+{{/* check if any Volume PVC exists */}}
 {{- define "volume.pvc_exists" -}}
 {{- if or (or (eq .Values.volume.data.type "persistentVolumeClaim") (and (eq .Values.volume.idx.type "persistentVolumeClaim") .Values.volume.dir_idx )) (eq .Values.volume.logs.type "persistentVolumeClaim") -}}
 {{- printf "true" -}}
@@ -122,7 +122,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 
-{{/* check if any HostPath exists */}}
+{{/* check if any Volume HostPath exists */}}
 {{- define "volume.hostpath_exists" -}}
 {{- if or (or (eq .Values.volume.data.type "hostPath") (and (eq .Values.volume.idx.type "hostPath") .Values.volume.dir_idx )) (eq .Values.volume.logs.type "hostPath") -}}
 {{- printf "true" -}}
@@ -132,5 +132,23 @@ Inject extra environment vars in the format key:value, if populated
 {{- else -}}
 {{- printf "false" -}}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* check if any Filer PVC exists */}}
+{{- define "filer.pvc_exists" -}}
+{{- if or (eq .Values.filer.data.type "persistentVolumeClaim") (eq .Values.filer.logs.type "persistentVolumeClaim") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "false" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* check if any Filer HostPath exists */}}
+{{- define "filer.hostpath_exists" -}}
+{{- if or (eq .Values.filer.data.type "hostPath") (eq .Values.filer.logs.type "hostPath") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "false" -}}
 {{- end -}}
 {{- end -}}

--- a/k8s/helm_charts2/templates/_helpers.tpl
+++ b/k8s/helm_charts2/templates/_helpers.tpl
@@ -152,3 +152,25 @@ Inject extra environment vars in the format key:value, if populated
 {{- printf "false" -}}
 {{- end -}}
 {{- end -}}
+
+{{/* check if any Master PVC exists */}}
+{{- define "master.pvc_exists" -}}
+{{- if or (eq .Values.master.data.type "persistentVolumeClaim") (eq .Values.master.logs.type "persistentVolumeClaim") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "false" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* check if any Master HostPath exists */}}
+{{- define "master.hostpath_exists" -}}
+{{- if or (eq .Values.master.data.type "hostPath") (eq .Values.master.logs.type "hostPath") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- if or .Values.global.enableSecurity .Values.volume.extraVolumes -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "false" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/k8s/helm_charts2/templates/filer-statefulset.yaml
+++ b/k8s/helm_charts2/templates/filer-statefulset.yaml
@@ -216,10 +216,18 @@ spec:
             {{ tpl .Values.filer.resources . | nindent 12 | trim }}
           {{- end }}
       volumes:
+        {{- if eq .Values.filer.logs.type "hostPath" }}
         - name: seaweedfs-filer-log-volume
           hostPath:
             path: /storage/logs/seaweedfs/filer
             type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.filer.data.type "hostPath" }}
+        - name: data-filer
+          hostPath:
+            path: /storage/filer_store
+            type: DirectoryOrCreate
+        {{- end }}
         - name: db-schema-config-volume
           configMap:
             name: seaweedfs-db-init-config
@@ -253,6 +261,7 @@ spec:
         {{ tpl .Values.filer.nodeSelector . | indent 8 | trim }}
       {{- end }}
   {{- if .Values.filer.enablePVC }}
+  # DEPRECATION: Deprecate in favor of filer.data section below
   volumeClaimTemplates:
   - metadata:
       name: data-filer
@@ -265,5 +274,29 @@ spec:
       {{- if .Values.filer.storageClass }}
       storageClassName: {{ .Values.filer.storageClass }}
       {{- end }}
+  {{- end }}
+  {{- $pvc_exists := include "filer.pvc_exists" . -}}
+  {{- if $pvc_exists }}
+  volumeClaimTemplates:
+    {{- if eq .Values.filer.data.type "persistentVolumeClaim"}}
+    - metadata:
+        name: data-filer
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.filer.data.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.filer.data.size }}
+    {{- end }}
+    {{- if eq .Values.filer.logs.type "persistentVolumeClaim"}}
+    - metadata:
+        name: seaweedfs-filer-log-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.filer.logs.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.filer.logs.size }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/k8s/helm_charts2/templates/master-statefulset.yaml
+++ b/k8s/helm_charts2/templates/master-statefulset.yaml
@@ -178,15 +178,21 @@ spec:
           resources:
             {{ tpl .Values.master.resources . | nindent 12 | trim }}
           {{- end }}
+      {{- $hostpath_exists := include "master.hostpath_exists" . -}}
+      {{- if $hostpath_exists }}
       volumes:
+        {{- if eq .Values.master.logs.type "hostPath" }}
         - name: seaweedfs-master-log-volume
           hostPath:
             path: /storage/logs/seaweedfs/master
             type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.master.data.type "hostPath" }}
         - name: data-{{ .Release.Namespace }}
           hostPath:
             path: /ssd/seaweed-master/
             type: DirectoryOrCreate
+        {{- end }}
         {{- if .Values.global.enableSecurity }}
         - name: security-config
           configMap:
@@ -208,20 +214,33 @@ spec:
             secretName: {{ template "seaweedfs.name" . }}-client-cert
         {{- end }}
         {{ tpl .Values.master.extraVolumes . | indent 8 | trim }}
+      {{- end }}
       {{- if .Values.master.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.master.nodeSelector . | indent 8 | trim }}
       {{- end }}
-{{/*  volumeClaimTemplates:*/}}
-{{/*    - metadata:*/}}
-{{/*        name: data-{{ .Release.Namespace }}*/}}
-{{/*      spec:*/}}
-{{/*        accessModes:*/}}
-{{/*          - ReadWriteOnce*/}}
-{{/*        resources:*/}}
-{{/*          requests:*/}}
-{{/*            storage: {{ .Values.master.storage }}*/}}
-{{/*        {{- if .Values.master.storageClass }}*/}}
-{{/*        storageClassName: {{ .Values.master.storageClass }}*/}}
-{{/*        {{- end }}*/}}
+  {{- $pvc_exists := include "volume.pvc_exists" . -}}
+  {{- if $pvc_exists }}
+  volumeClaimTemplates:
+    {{- if eq .Values.master.data.type "persistentVolumeClaim"}}
+    - metadata:
+        name: data-{{ .Release.Namespace }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.master.data.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.master.data.size }}
+    {{- end }}
+    {{- if eq .Values.master.logs.type "persistentVolumeClaim"}}
+    - metadata:
+        name: seaweedfs-master-log-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.master.logs.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.master.logs.size }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/k8s/helm_charts2/values.yaml
+++ b/k8s/helm_charts2/values.yaml
@@ -58,6 +58,21 @@ master:
   # Disable http request, only gRpc operations are allowed
   disableHttp: false
 
+  # can use ANY storage-class , example with local-path-provisioner
+  #  data:
+  #    type: "persistentVolumeClaim"
+  #    size: "24Ti"
+  #    storageClass: "local-path-provisioner"
+  data:
+    type: "hostPath"
+    size: ""
+    storageClass: ""
+
+  logs:
+    type: "hostPath"
+    size: ""
+    storageClass: ""
+
   extraVolumes: ""
   extraVolumeMounts: ""
 

--- a/k8s/helm_charts2/values.yaml
+++ b/k8s/helm_charts2/values.yaml
@@ -76,13 +76,6 @@ master:
   extraVolumes: ""
   extraVolumeMounts: ""
 
-  # storage and storageClass are the settings for configuring stateful
-  # storage for the master pods. storage should be set to the disk size of
-  # the attached volume. storageClass is the class of storage which defaults
-  # to null (the Kube cluster will pick the default).
-  storage: 25Gi
-  storageClass: null
-
   # Resource requests, limits, etc. for the master cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request

--- a/k8s/helm_charts2/values.yaml
+++ b/k8s/helm_charts2/values.yaml
@@ -156,7 +156,7 @@ volume:
   # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
   minFreeSpacePercent: 7
 
-# can use ANY storage-class , example with local-path-provisner
+# can use ANY storage-class , example with local-path-provisioner
 #  data:
 #    type: "persistentVolumeClaim"
 #    size: "24Ti"
@@ -275,15 +275,31 @@ filer:
   # Disable http request, only gRpc operations are allowed
   disableHttp: false
 
+  # DEPRECATE: enablePVC, storage, storageClass
+  # Consider replacing with filer.data section below instead.
+
+  # Settings for configuring stateful storage of filer pods.
   # enablePVC will create a pvc for filer for data persistence.
   enablePVC: false
-
-  # storage and storageClass are the settings for configuring stateful
-  # storage for the master pods. storage should be set to the disk size of
-  # the attached volume. storageClass is the class of storage which defaults
-  # to null (the Kube cluster will pick the default).
+  # storage should be set to the disk size of the attached volume.
   storage: 25Gi
+  # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
   storageClass: null
+
+  # can use ANY storage-class , example with local-path-provisioner
+  #  data:
+  #    type: "persistentVolumeClaim"
+  #    size: "24Ti"
+  #    storageClass: "local-path-provisioner"
+  data:
+    type: "hostPath"
+    size: ""
+    storageClass: ""
+
+  logs:
+    type: "hostPath"
+    size: ""
+    storageClass: ""
 
   extraVolumes: ""
   extraVolumeMounts: ""


### PR DESCRIPTION
# What problem are we solving?

Currently k8s HostPath Volumes are used for the following:
- Filer
  - Logs
- Master
  - Data
  - Log
  
HostPath Volumes are known to present security risks and has a [warning attached in the k8s documentation](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath).

# How are we solving the problem?

This PR gives the users the option to use PersistentVolumeClaims in-place of HostPath volumes. This PR follows and extends existing conventions, like the ones used for [volumes](https://github.com/chrislusf/seaweedfs/blob/master/k8s/helm_charts2/templates/volume-statefulset.yaml#L245-L254).

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
