### PR TITLE
no need to load needlemap from the begaining when GC

### DIFF
--- a/weed/storage/needle_map_memory.go
+++ b/weed/storage/needle_map_memory.go
@@ -14,9 +14,14 @@ type NeedleMap struct {
 	m needle_map.NeedleValueMap
 }
 
-func NewCompactNeedleMap(file *os.File) *NeedleMap {
-	nm := &NeedleMap{
-		m: needle_map.NewCompactMap(),
+func NewCompactNeedleMap(file *os.File, oldNm *NeedleMap) *NeedleMap {
+	var nm *NeedleMap
+	if oldNm == nil {
+		nm = &NeedleMap{
+			m: needle_map.NewCompactMap(),
+		}
+	} else {
+		nm = oldNm
 	}
 	nm.indexFile = file
 	stat, err := file.Stat()
@@ -27,13 +32,13 @@ func NewCompactNeedleMap(file *os.File) *NeedleMap {
 	return nm
 }
 
-func LoadCompactNeedleMap(file *os.File) (*NeedleMap, error) {
-	nm := NewCompactNeedleMap(file)
-	return doLoading(file, nm)
+func LoadCompactNeedleMap(file *os.File, oldNm *NeedleMap, idxOffset uint64) (*NeedleMap, error) {
+	nm := NewCompactNeedleMap(file, oldNm)
+	return doLoading(file, nm, idxOffset)
 }
 
-func doLoading(file *os.File, nm *NeedleMap) (*NeedleMap, error) {
-	e := idx.WalkIndexFile(file, 0, func(key NeedleId, offset Offset, size Size) error {
+func doLoading(file *os.File, nm *NeedleMap, idxOffset uint64) (*NeedleMap, error) {
+	e := idx.WalkIndexFile(file, idxOffset, func(key NeedleId, offset Offset, size Size) error {
 		nm.MaybeSetMaxFileKey(key)
 		if !offset.IsZero() && size.IsValid() {
 			nm.FileCounter++

--- a/weed/storage/needle_map_metric_test.go
+++ b/weed/storage/needle_map_metric_test.go
@@ -12,7 +12,7 @@ import (
 func TestFastLoadingNeedleMapMetrics(t *testing.T) {
 
 	idxFile, _ := os.CreateTemp("", "tmp.idx")
-	nm := NewCompactNeedleMap(idxFile)
+	nm := NewCompactNeedleMap(idxFile, nil)
 
 	for i := 0; i < 10000; i++ {
 		nm.Put(Uint64ToNeedleId(uint64(i+1)), Uint32ToOffset(uint32(0)), Size(1))

--- a/weed/storage/volume.go
+++ b/weed/storage/volume.go
@@ -57,7 +57,7 @@ func NewVolume(dirname string, dirIdx string, collection string, id needle.Volum
 		asyncRequestsChan: make(chan *needle.AsyncRequest, 128)}
 	v.SuperBlock = super_block.SuperBlock{ReplicaPlacement: replicaPlacement, Ttl: ttl}
 	v.needleMapKind = needleMapKind
-	e = v.load(true, true, needleMapKind, preallocate)
+	e = v.load(true, true, needleMapKind, preallocate, 0)
 	v.startWorker()
 	return
 }


### PR DESCRIPTION
# What problem are we solving?

when committing compact and loadling new idx file to memory. No need to  read idx from the begaining, just from the offset of new idx files. The offset equals size of  old idx file.

# How are we solving the problem?
Loading idx to memory costs too much time.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
