### PR TITLE
[filer] sync/backup/replicate exclude directories to sync on filer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,5 @@ install:
 full_install:
 	cd weed; go install -tags "elastic gocdk sqlite ydb tikv"
 
-test:
+tests:
 	cd weed; go test -tags "elastic gocdk sqlite ydb tikv" -v ./...

--- a/weed/command/scaffold/replication.toml
+++ b/weed/command/scaffold/replication.toml
@@ -13,6 +13,8 @@ grpcAddress = "localhost:18888"
 # this is not a directory on your hard drive, but on your filer.
 # i.e., all files with this "prefix" are sent to notification message queue.
 directory = "/buckets"
+# files from the directory separated by space are excluded from sending notifications
+excludeDirectories = "/buckets/tmp"
 
 [sink.local]
 enabled = false

--- a/weed/replication/replicator.go
+++ b/weed/replication/replicator.go
@@ -16,8 +16,9 @@ import (
 )
 
 type Replicator struct {
-	sink   sink.ReplicationSink
-	source *source.FilerSource
+	sink        sink.ReplicationSink
+	source      *source.FilerSource
+	excludeDirs []string
 }
 
 func NewReplicator(sourceConfig util.Configuration, configPrefix string, dataSink sink.ReplicationSink) *Replicator {
@@ -28,8 +29,9 @@ func NewReplicator(sourceConfig util.Configuration, configPrefix string, dataSin
 	dataSink.SetSourceFiler(source)
 
 	return &Replicator{
-		sink:   dataSink,
-		source: source,
+		sink:        dataSink,
+		source:      source,
+		excludeDirs: sourceConfig.GetStringSlice(configPrefix + "excludeDirectories"),
 	}
 }
 
@@ -41,6 +43,13 @@ func (r *Replicator) Replicate(ctx context.Context, key string, message *filer_p
 		glog.V(4).Infof("skipping %v outside of %v", key, r.source.Dir)
 		return nil
 	}
+	for _, excludeDir := range r.excludeDirs {
+		if strings.HasPrefix(key, excludeDir) {
+			glog.V(4).Infof("skipping %v of exclude dir %v", key, excludeDir)
+			return nil
+		}
+	}
+
 	var dateKey string
 	if r.sink.IsIncremental() {
 		var mTime int64


### PR DESCRIPTION
# What problem are we solving?

There are buckets of many temporary files that do not need to be synchronized or backup

# How are we solving the problem?
Add option with exclude directories to sync on filer

# Checks
- [ok] I have added unit tests if possible.
- [ok] I will add related wiki document changes and link to this PR after merging.
