### PR TITLE
fix: Buckets are not created and deleted correctly on the filer with …

### DIFF
--- a/weed/filer/filer_on_meta_event.go
+++ b/weed/filer/filer_on_meta_event.go
@@ -16,11 +16,7 @@ func (f *Filer) onMetadataChangeEvent(event *filer_pb.SubscribeMetadataResponse)
 
 func (f *Filer) onBucketEvents(event *filer_pb.SubscribeMetadataResponse) {
 	message := event.EventNotification
-	for _, sig := range message.Signatures {
-		if sig == f.Signature {
-			return
-		}
-	}
+
 	if f.DirBucketsPath == event.Directory {
 		if filer_pb.IsCreate(event) {
 			if message.NewEntry.IsDirectory {


### PR DESCRIPTION
Buckets are not created and deleted correctly on the filer with the same signature when they are created and deleted

# What problem are we solving?

When the bucket is created, the corresponding table cannot be created

# How are we solving the problem?

Remove signature verification

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
