### PR TITLE
PutUserAction should completely replace identity actions

### DIFF
--- a/weed/iamapi/iamapi_management_handlers.go
+++ b/weed/iamapi/iamapi_management_handlers.go
@@ -219,17 +219,7 @@ func (iama *IamApiServer) PutUserPolicy(s3cfg *iam_pb.S3ApiConfiguration, values
 		if userName != ident.Name {
 			continue
 		}
-
-		existedActions := make(map[string]bool, len(ident.Actions))
-		for _, action := range ident.Actions {
-			existedActions[action] = true
-		}
-
-		for _, action := range actions {
-			if !existedActions[action] {
-				ident.Actions = append(ident.Actions, action)
-			}
-		}
+		ident.Actions = actions
 		return resp, nil
 	}
 	return resp, fmt.Errorf("%s: the user with name %s cannot be found", iam.ErrCodeNoSuchEntityException, userName)


### PR DESCRIPTION
# What problem are we solving?

PutUserAction should replace an identity's action list. Currently, there is no way to remove an action using IAM API.
Discussion: https://github.com/chrislusf/seaweedfs/discussions/3376

# How are we solving the problem?

Just replace the identity's action list by the API input

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
