### PR TITLE
fix(worker): prevent deadlock on stop by using buffered channel

### DIFF
--- a/weed/worker/worker.go
+++ b/weed/worker/worker.go
@@ -185,7 +185,7 @@ func NewWorker(config *types.WorkerConfig) (*Worker, error) {
 		config:         config,
 		registry:       registry,
 		taskLogHandler: taskLogHandler,
-		cmds:           make(chan workerCommand),
+		cmds:           make(chan workerCommand, 16),
 	}
 
 	glog.V(1).Infof("Worker created with %d registered task types", len(registry.GetAll()))


### PR DESCRIPTION
## What problem are we solving?

When `Stop()` is called on a worker, the `managerLoop` goroutine exits and stops consuming from the `w.cmds` channel. However, other goroutines (e.g., `executeTask`) may still be running and will attempt to send completion or failure signals to `w.cmds` after the loop has stopped.

Since `cmds` is an **unbuffered channel**, these send operations block forever. This prevents `w.wg.Wait()` in `Stop()` from ever returning, causing a deadlock and preventing graceful shutdown of the worker.

## How are we solving the problem?

Change the `cmds` channel from unbuffered (`make(chan workerCommand)`) to a **buffered channel with capacity 16** (`make(chan workerCommand, 16)`).

This allows a small backlog of pending commands to be buffered even after the manager loop stops, unblocking the sender goroutines. Once the senders are unblocked, they can finish, and `wg.Wait()` can proceed normally.

The capacity of 16 is safe and only affects shutdown paths, with negligible memory overhead.

## How is the PR tested?

- This change only affects the shutdown/error handling path, which is difficult to deterministically test in a unit test due to race conditions.
- Existing tests (`go test ./weed/worker/...`) pass locally, confirming no regression.
- The fix is minimal (1 line) and the logic is clearly correct for this specific concurrency scenario.

## Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again.

## Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.
