### PR TITLE
s3: fail closed on unsupported bucket-policy condition operators

### DIFF
--- a/weed/s3api/policy_engine/conditions.go
+++ b/weed/s3api/policy_engine/conditions.go
@@ -813,7 +813,7 @@ func EvaluateConditions(conditions PolicyConditions, contextValues map[string][]
 		conditionEvaluator, err := GetConditionEvaluator(operator)
 		if err != nil {
 			glog.Warningf("Unsupported condition operator: %s", operator)
-			continue
+			return false
 		}
 
 		for key, value := range conditionMap {
@@ -848,13 +848,13 @@ func EvaluateConditionsLegacy(conditions map[string]interface{}, contextValues m
 		conditionEvaluator, err := GetConditionEvaluator(operator)
 		if err != nil {
 			glog.Warningf("Unsupported condition operator: %s", operator)
-			continue
+			return false
 		}
 
 		conditionMapTyped, ok := conditionMap.(map[string]interface{})
 		if !ok {
 			glog.Warningf("Invalid condition format for operator: %s", operator)
-			continue
+			return false
 		}
 
 		for key, value := range conditionMapTyped {

--- a/weed/s3api/policy_engine/conditions.go
+++ b/weed/s3api/policy_engine/conditions.go
@@ -233,6 +233,66 @@ func (e *StringNotLikeEvaluator) Evaluate(conditionValue interface{}, contextVal
 	return true
 }
 
+// StringEqualsIgnoreCaseEvaluator evaluates StringEqualsIgnoreCase conditions
+type StringEqualsIgnoreCaseEvaluator struct{}
+
+func (e *StringEqualsIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
+	expectedValues := getCachedNormalizedValues(conditionValue)
+	for _, expected := range expectedValues {
+		for _, contextValue := range contextValues {
+			if strings.EqualFold(expected, contextValue) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// StringNotEqualsIgnoreCaseEvaluator evaluates StringNotEqualsIgnoreCase conditions
+type StringNotEqualsIgnoreCaseEvaluator struct{}
+
+func (e *StringNotEqualsIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
+	expectedValues := getCachedNormalizedValues(conditionValue)
+	for _, expected := range expectedValues {
+		for _, contextValue := range contextValues {
+			if strings.EqualFold(expected, contextValue) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// StringLikeIgnoreCaseEvaluator evaluates StringLikeIgnoreCase conditions
+type StringLikeIgnoreCaseEvaluator struct{}
+
+func (e *StringLikeIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
+	patterns := getCachedNormalizedValues(conditionValue)
+	for _, pattern := range patterns {
+		for _, contextValue := range contextValues {
+			if MatchesWildcard(strings.ToLower(pattern), strings.ToLower(contextValue)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// StringNotLikeIgnoreCaseEvaluator evaluates StringNotLikeIgnoreCase conditions
+type StringNotLikeIgnoreCaseEvaluator struct{}
+
+func (e *StringNotLikeIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
+	patterns := getCachedNormalizedValues(conditionValue)
+	for _, pattern := range patterns {
+		for _, contextValue := range contextValues {
+			if MatchesWildcard(strings.ToLower(pattern), strings.ToLower(contextValue)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // NumericEqualsEvaluator evaluates NumericEquals conditions
 type NumericEqualsEvaluator struct{}
 
@@ -665,6 +725,14 @@ func GetConditionEvaluator(operator string) (ConditionEvaluator, error) {
 		return &StringLikeEvaluator{}, nil
 	case "StringNotLike":
 		return &StringNotLikeEvaluator{}, nil
+	case "StringEqualsIgnoreCase":
+		return &StringEqualsIgnoreCaseEvaluator{}, nil
+	case "StringNotEqualsIgnoreCase":
+		return &StringNotEqualsIgnoreCaseEvaluator{}, nil
+	case "StringLikeIgnoreCase":
+		return &StringLikeIgnoreCaseEvaluator{}, nil
+	case "StringNotLikeIgnoreCase":
+		return &StringNotLikeIgnoreCaseEvaluator{}, nil
 	case "NumericEquals":
 		return &NumericEqualsEvaluator{}, nil
 	case "NumericNotEquals":

--- a/weed/s3api/policy_engine/conditions_failclosed_test.go
+++ b/weed/s3api/policy_engine/conditions_failclosed_test.go
@@ -1,0 +1,31 @@
+package policy_engine
+
+import (
+	"testing"
+)
+
+func TestEvaluateConditionsFailsClosedOnUnsupportedOperator(t *testing.T) {
+	conditions := PolicyConditions{
+		"StringEqualsBogus": {
+			"aws:username": NewStringOrStringSlice("alice"),
+		},
+	}
+	contextValues := map[string][]string{}
+	got := EvaluateConditions(conditions, contextValues, nil, nil)
+	if got {
+		t.Fatalf("EvaluateConditions returned true for unsupported operator; expected false (fail closed)")
+	}
+}
+
+func TestEvaluateConditionsLegacyFailsClosedOnUnsupportedOperator(t *testing.T) {
+	conditions := map[string]interface{}{
+		"StringEqualsBogus": map[string]interface{}{
+			"aws:username": "alice",
+		},
+	}
+	contextValues := map[string][]string{}
+	got := EvaluateConditionsLegacy(conditions, contextValues, nil)
+	if got {
+		t.Fatalf("EvaluateConditionsLegacy returned true for unsupported operator; expected false (fail closed)")
+	}
+}

--- a/weed/s3api/policy_engine/conditions_ignorecase_test.go
+++ b/weed/s3api/policy_engine/conditions_ignorecase_test.go
@@ -1,0 +1,37 @@
+package policy_engine
+
+import (
+	"testing"
+)
+
+func TestConditionEvaluatorsIgnoreCase(t *testing.T) {
+	tests := []struct {
+		name           string
+		operator       string
+		conditionValue interface{}
+		contextValues  []string
+		expected       bool
+	}{
+		{"StringEqualsIgnoreCase - match", "StringEqualsIgnoreCase", "ALICE", []string{"alice"}, true},
+		{"StringEqualsIgnoreCase - no match", "StringEqualsIgnoreCase", "alice", []string{"bob"}, false},
+		{"StringNotEqualsIgnoreCase - match", "StringNotEqualsIgnoreCase", "alice", []string{"bob"}, true},
+		{"StringNotEqualsIgnoreCase - no match", "StringNotEqualsIgnoreCase", "ALICE", []string{"alice"}, false},
+		{"StringLikeIgnoreCase - wildcard match", "StringLikeIgnoreCase", "TEST-*", []string{"test-value"}, true},
+		{"StringLikeIgnoreCase - wildcard no match", "StringLikeIgnoreCase", "TEST-*", []string{"other-value"}, false},
+		{"StringNotLikeIgnoreCase - wildcard match", "StringNotLikeIgnoreCase", "TEST-*", []string{"other-value"}, true},
+		{"StringNotLikeIgnoreCase - wildcard no match", "StringNotLikeIgnoreCase", "TEST-*", []string{"test-value"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluator, err := GetConditionEvaluator(tt.operator)
+			if err != nil {
+				t.Fatalf("Failed to get condition evaluator: %v", err)
+			}
+			result := evaluator.Evaluate(tt.conditionValue, tt.contextValues)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/weed/s3api/policy_engine/conditions_validation_test.go
+++ b/weed/s3api/policy_engine/conditions_validation_test.go
@@ -1,0 +1,62 @@
+package policy_engine
+
+import (
+	"testing"
+)
+
+func TestValidatePolicyRejectsUnsupportedConditionOperator(t *testing.T) {
+	tests := []struct {
+		name        string
+		policyJSON  string
+		expectError bool
+	}{
+		{
+			name: "unsupported operator rejected",
+			policyJSON: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:GetObject",
+					"Resource": "arn:aws:s3:::test-bucket/*",
+					"Condition": {"StringEqualsBogus": {"aws:username": "alice"}}
+				}]
+			}`,
+			expectError: true,
+		},
+		{
+			name: "supported IgnoreCase operator accepted",
+			policyJSON: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:GetObject",
+					"Resource": "arn:aws:s3:::test-bucket/*",
+					"Condition": {"StringEqualsIgnoreCase": {"aws:username": "alice"}}
+				}]
+			}`,
+			expectError: false,
+		},
+		{
+			name: "supported StringEquals operator accepted",
+			policyJSON: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:GetObject",
+					"Resource": "arn:aws:s3:::test-bucket/*",
+					"Condition": {"StringEquals": {"aws:username": "alice"}}
+				}]
+			}`,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePolicy(tt.policyJSON)
+			if (err != nil) != tt.expectError {
+				t.Errorf("ParsePolicy expected error: %v, got: %v", tt.expectError, err)
+			}
+		})
+	}
+}

--- a/weed/s3api/policy_engine/types.go
+++ b/weed/s3api/policy_engine/types.go
@@ -227,6 +227,12 @@ func validateStatement(stmt *PolicyStatement) error {
 		return fmt.Errorf("statement must specify Resource or NotResource")
 	}
 
+	for operator := range stmt.Condition {
+		if _, err := GetConditionEvaluator(operator); err != nil {
+			return fmt.Errorf("unsupported condition operator %q: %v", operator, err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

The S3 bucket-policy condition engine failed open on unrecognized condition operators. `EvaluateConditions` logged a warning and `continue`d past an unsupported operator, leaving no condition to fail, so it returned `true` and made a conditional `Allow` statement unconditional. This could let an unauthenticated request bypass a non-matching condition (e.g. a `StringEquals: aws:username` guard) and read private objects, simply by using an operator the engine does not recognize.

This is split into three focused commits:

1. **Support the IgnoreCase string operators** (`StringEqualsIgnoreCase`, `StringNotEqualsIgnoreCase`, `StringLikeIgnoreCase`, `StringNotLikeIgnoreCase`) in the S3 policy engine. These are valid AWS operators that the IAM policy engine already supports; adding them here means legitimate policies evaluate correctly instead of falling into the unsupported-operator path.
2. **Reject policies with unsupported condition operators at upload/parse time.** `validateStatement` now reuses `GetConditionEvaluator` to reject unknown operators, so a typo or unsupported key is refused when the policy is stored rather than silently skipped later.
3. **Fail closed at evaluation time.** `EvaluateConditions` and `EvaluateConditionsLegacy` now return `false` on an unsupported operator instead of skipping it, so an unrecognized operator fails the condition block (the statement does not match) rather than granting access. This mirrors the fail-closed posture of the IAM policy engine.

The three changes are independent: (1) makes valid operators work, (2) catches unknown operators at the entry point, and (3) is defense in depth so an unknown operator can never widen access if it reaches evaluation.

#### Test plan
- [x] \`go test ./weed/s3api/policy_engine/\` — new tests for the IgnoreCase evaluators, validation rejection, and fail-closed behavior
- [x] \`go test ./weed/s3api/...\` — no regressions
- [x] \`go build ./weed\` — builds cleanly
- [ ] CI